### PR TITLE
support fairly free annotations for tables without monkeying with database

### DIFF
--- a/censusreporter/apps/census/templates/table/specific/B02003.html
+++ b/censusreporter/apps/census/templates/table/specific/B02003.html
@@ -1,0 +1,6 @@
+{% extends "table/specific/_base_specific.html" %}
+{% block table_specific %}
+<p class="explain">
+    Because the columns in <strong>B02003</strong> are so detailed, this table is only available for the entire US, and is only included in the 1-year and 3-year ACS releases. If you want similar information for any other geographies or for the 5-year ACS, use table <a href='{% url "table_detail" "C02003" %}'>C02003</a>
+</p>
+{% endblock %}

--- a/censusreporter/apps/census/templates/table/specific/_base_specific.html
+++ b/censusreporter/apps/census/templates/table/specific/_base_specific.html
@@ -1,0 +1,10 @@
+<div id="table-specific">
+<h4>About this table</h4>
+{% block table_specific %}
+<p class="explain">
+Extend this template to maintain consistency.
+Fill in this block with details specific to a table. 
+Don't forget to use the 'explain' class on your &lt;p&gt; tags.
+</p>
+{% endblock %}
+</div>

--- a/censusreporter/apps/census/templates/table/table_detail.html
+++ b/censusreporter/apps/census/templates/table/table_detail.html
@@ -1,5 +1,5 @@
 {% extends 'table/_base_table.html' %}
-
+{% load tabletags %}
 {% block head_title %}Table {{ table.table_id }}: {{ table.simple_table_title }} - {{ block.super }}{% endblock %}
 
 {% block head_facebook_tags %}
@@ -72,6 +72,7 @@
             <div class="column-golden-narrow">
                 {% if related_topic_pages %}
                 <div class="sidebar-block">
+                    {% table_specific table.table_id  %}
                     <h4>Background on table topics</h4>
                     <p class="explain"><a href="{% url 'topic_list' %}">Topic pages</a> describe concepts covered by the ACS. For background on the topics in Table {{ table.table_id }}, see:</p>
                     <ul>{% for slug, title in related_topic_pages %}

--- a/censusreporter/apps/census/templatetags/tabletags.py
+++ b/censusreporter/apps/census/templatetags/tabletags.py
@@ -1,0 +1,13 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def table_specific(context, table_id):
+    """Safely include a fragment specific to the given table, but handle no special info gracefully."""
+    try:
+        fragment_path = "table/specific/%s.html" % table_id
+        t = template.loader.get_template(fragment_path)
+        return t.render(context)
+    except template.TemplateDoesNotExist:
+        return ""


### PR DESCRIPTION
@ryanpitts whaddaya think about this approach? I like that it's more freeform than jamming the answers into the database, or even references to the fragments. I'm expecting there won't be _that many_ of these, and that they'll all be different. There are a few other "US-only" tables, like the detailed income by occupation, etc.
