### PR TITLE
Use comparison.geoSearchAPI variable correctly

### DIFF
--- a/censusreporter/apps/census/static/js/comparisons.js
+++ b/censusreporter/apps/census/static/js/comparisons.js
@@ -1035,7 +1035,7 @@ function Comparison(options) {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         limit: 20,
         remote: {
-            url: geoSearchAPI,
+            url: comparison.geoSearchAPI,
             replace: function (url, query) {
                 return url += '?q=' + query + '&sumlevs=' + comparison.chosenSumlevAncestorList;
             },


### PR DESCRIPTION
Comparison.js was picking up a global geoSearchAPI from somewhere when it should have been using
the one on the comparison object.
