### PR TITLE
Include current column id in map view URL to facilitate sharing

### DIFF
--- a/censusreporter/apps/census/static/js/comparisons.js
+++ b/censusreporter/apps/census/static/js/comparisons.js
@@ -328,7 +328,11 @@ function Comparison(options) {
         // add the "change summary level" picker
 
         comparison.sortedSumlevList = comparison.makeSortedSumlevMap(comparison.sumlevMap);
-        comparison.chosenSumlev = comparison.hash.sumlev || comparison.sortedSumlevList[0]['sumlev'];
+        if (comparison.hash.sumlev && sumlevMap[comparison.hash.sumlev]) {
+            comparison.chosenSumlev = comparison.hash.sumlev || comparison.sortedSumlevList[0]['sumlev'];
+        } else {
+            comparison.chosenSumlev = comparison.sortedSumlevList[0]['sumlev'];
+        }
 
         comparison.headerContainer.select('#sumlev-select').remove();
         var sumlevSelector = comparison.headerContainer.append('div')
@@ -1460,10 +1464,9 @@ function Comparison(options) {
         }
 
         if (dataFormat == 'map') {
-            comparison.hash = {
-                column: comparison.chosenColumn,
-                sumlev: comparison.chosenSumlev,
-            }
+            comparison.hash = {};
+            if (comparison.chosenColumn) comparison.hash.column = comparison.chosenColumn;
+            if (comparison.chosenSumlev) comparison.hash.sumlev = comparison.chosenSumlev;
         }
 
         if (!!comparison.hash) {


### PR DESCRIPTION
Include the column id in the anchor portion of the url (eg. `#col-B12345`) to facilitate link sharing, since the map really depends heavily on the column being shown.
