### PR TITLE
Fix usage of d3.map.

### DIFF
--- a/censusreporter/apps/census/static/js/charts.js
+++ b/censusreporter/apps/census/static/js/charts.js
@@ -72,7 +72,7 @@ function Chart(options) {
         // keep the initial data for possible display later
         chart.initialData = options.chartData;
         
-        chart.chartDataValues = d3.values(chart.chartDataValues).filter(function(n){return typeof(n) != 'function'}).map(function(d) {
+        chart.chartDataValues = chart.chartDataValues.values().filter(function(n){return typeof(n) != 'function'}).map(function(d) {
             if (chart.chartType.indexOf('grouped_') != -1) {
                 // data shaped for grouped-column or -bar presentation
                 dataObj = {
@@ -545,7 +545,7 @@ function Chart(options) {
         });
 
         // create array of categories specific to this chart
-        chart.chartCategories = d3.values(chart.chartDataValues).map(function(d) {
+        chart.chartCategories = chart.chartDataValues.map(function(d) {
             return d.name
         });
         


### PR DESCRIPTION
As of D3 version 3.4.13, the internal, private API of d3.map has changed
so that properties are not stored on the d3.map instance directly.  This
means that d3.values(d3.map({a: 1})) no longer returns [1].  Instead,
the public d3.map APIs should be used: d3.map({a: 1}).values().

I’ve also removed what looks like a redundant call to d3.values on an
array.
