### PR TITLE
Ensure graphs show up in print

### DIFF
--- a/censusreporter/apps/census/static/css/charts.css
+++ b/censusreporter/apps/census/static/css/charts.css
@@ -121,6 +121,15 @@ uncomment for separate inclusion into embed iframes */
     margin: .5em 0 0;
 }
 
+/* force column and area graphs to print correctly
+ * see http://stackoverflow.com/questions/6553439/div-background-color-in-print-page-dont-work */
+@media print {
+    .bar .area,
+    .column .area {
+        box-shadow: inset 0 0 0 1000px grey;
+    }
+}
+
 .column .label,
 .column-group .label {
     position: absolute;


### PR DESCRIPTION
Backporting a quick hack we added at a request from a user that ensures bar and column graphs show up when the profile page is printed. By default, printing webpages doesn't show background colours so the graphs don't show up.

This doesn't use nice colours or use separate colours for grouped charts, but it's a start.