### PR TITLE
WIP embed code pulls from release-specific and chart-specific json

### DIFF
--- a/censusreporter/apps/census/static/js/charts.js
+++ b/censusreporter/apps/census/static/js/charts.js
@@ -742,12 +742,12 @@ function Chart(options) {
         var embedHeight = 300,
             embedWidth = (chart.chartType == 'pie') ? 300 : 720,
             embedKey = chart.chartDataKey.substring(chart.chartDataKey.indexOf('-')+1),
-            embedDataYear = chart.initialData.metadata.acs_release.split(' ')[1],
+            embedReleaseID = chart.initialData.metadata.acs_release.replace(/ /g,'_'),
             embedID = 'cr-embed-'+chart.primaryGeoID+'-'+embedKey,
             embedParams = {
                 geoID: chart.primaryGeoID,
                 chartDataID: embedKey,
-                dataYear: embedDataYear,
+                releaseID: embedReleaseID,
                 chartType: chart.chartType,
                 chartHeight: 200,
                 chartQualifier: (chart.chartQualifier || ''),
@@ -758,11 +758,17 @@ function Chart(options) {
             embedAlign = (align == 'left' || align == 'right') ? ' float: ' + align + ';' : '';
         
         var querystring = $.param(embedParams);
-        
         var embedCode = [
             '<iframe id="'+embedID+'" class="census-reporter-embed" src="https://s3.amazonaws.com/embed.censusreporter.org/1.0/iframe.html?'+querystring+'" frameborder="0" width="100%" height="300" style="margin: 1em; max-width: '+embedWidth+'px;' + embedAlign + '"></iframe>',
             '\n<script src="https://s3.amazonaws.com/embed.censusreporter.org/1.0/js/embed.chart.make.js"></script>'
         ].join('');
+        
+        $.post('/make-json/charts/', {
+            params: JSON.stringify(embedParams),
+            geography: JSON.stringify(profileData['geography']),
+            geo_metadata: JSON.stringify(profileData['geo_metadata']),
+            chart_data: JSON.stringify(chart.initialData)
+        })
         
         textarea.html(embedCode);
     }

--- a/censusreporter/apps/census/static/js/embed.chart.frame.js
+++ b/censusreporter/apps/census/static/js/embed.chart.frame.js
@@ -20,9 +20,15 @@ function makeEmbedFrame() {
         embedFrame.trackEvent('Embedded Charts', 'Parent URL', document.referrer);
 
         embedFrame.parentContainerID = 'cr-embed-'+embedFrame.params.geoID+'-'+embedFrame.params.chartDataID;
-        embedFrame.params.chartDataID = embedFrame.params.chartDataID.split('-');
+        embedFrame.params.chartDataPath = embedFrame.params.chartDataID.split('-');
         embedFrame.params.chartDataYearDir = (!!embedFrame.params.dataYear) ? embedFrame.params.dataYear+'/' : '';
-        embedFrame.dataSource = 'https://s3.amazonaws.com/embed.censusreporter.org/1.0/data/profiles/'+embedFrame.params.chartDataYearDir+embedFrame.params.geoID+'.json';
+
+        if (!!embedFrame.params.releaseID) {
+            embedFrame.dataSource = 'https://s3.amazonaws.com/embed.censusreporter.org/1.0/data/charts/'+embedFrame.params.releaseID+'/'+embedFrame.params.geoID+'-'+embedFrame.params.chartDataID+'.json';
+        } else {
+            // continue supporting embed code from before release-specific data storage
+            embedFrame.dataSource = 'https://s3.amazonaws.com/embed.censusreporter.org/1.0/data/profiles/'+embedFrame.params.chartDataYearDir+embedFrame.params.geoID+'.json';
+        }
         // avoid css media-query caching issues with multiple embeds on same page
         $('#chart-styles').attr('href','css/charts.css?'+embedFrame.parentContainerID)
         embedFrame.makeChartFooter();
@@ -32,11 +38,11 @@ function makeEmbedFrame() {
         $.getJSON(embedFrame.dataSource)
             .done(function(results) {
                 // allow arbitrary nesting in API data structure
-                var data = results[embedFrame.params.chartDataID[0]],
-                    drilldown = embedFrame.params.chartDataID.length - 1;
+                var data = results[embedFrame.params.chartDataPath[0]],
+                    drilldown = embedFrame.params.chartDataPath.length - 1;
                 if (drilldown >= 1) {
                     for (var i = 1; i <= drilldown; i++) {
-                        data = data[embedFrame.params.chartDataID[i]];
+                        data = data[embedFrame.params.chartDataPath[i]];
                     }
                 }
             

--- a/censusreporter/apps/census/templates/profile/profile_detail.html
+++ b/censusreporter/apps/census/templates/profile/profile_detail.html
@@ -323,6 +323,21 @@
 <!--<![endif]-->
 <script src="{{ STATIC_URL }}js/vendor/leaflet.label.js"></script>
 <script type="text/javascript">
+// Allow Ajax POST requests to bypass Django's CSRF check
+// https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
+var csrftoken = '{{ csrf_token }}';
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+        }
+    }
+});
+
 // Make the header map
 d3.json(CR_API_URL + '/1.0/geo/tiger2013/{{ geography.this.full_geoid }}?geom=true', function(error, json) {
     if (error) return console.warn(error);

--- a/censusreporter/apps/census/urls.py
+++ b/censusreporter/apps/census/urls.py
@@ -9,7 +9,8 @@ from django.views.generic.base import TemplateView, RedirectView
 from .utils import GEOGRAPHIES_MAP
 from .views import (HomepageView, GeographyDetailView, GeographySearchView,
     TableDetailView, TableSearchView, PlaceSearchJson, GeoSearch,
-    HealthcheckView, DataView, TopicView, ExampleView, Elasticsearch)
+    HealthcheckView, DataView, TopicView, ExampleView, Elasticsearch,
+    MakeJSONView)
 
 admin.autodiscover()
 
@@ -39,6 +40,13 @@ urlpatterns = patterns('',
         view    = cache_page(STANDARD_CACHE_TIME)(GeographySearchView.as_view()),
         kwargs  = {},
         name    = 'geography_search',
+    ),
+
+    url(
+        regex   = '^make-json/charts/$',
+        view    = MakeJSONView.as_view(),
+        kwargs  = {},
+        name    = 'make_json_charts',
     ),
 
     # e.g. /table/B01001/

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -573,7 +573,94 @@ class ComparisonBuilder(TemplateView):
 
         return page_context
 
+class S3Conn(object):
+    def make_s3(self):
+        if AWS_KEY and AWS_SECRET:
+            s3 = S3Connection(AWS_KEY, AWS_SECRET)
+        else:
+            try:
+                s3 = S3Connection()
+            except:
+                s3 = None
+        return s3
 
+    def s3_key(self, key_name):
+        s3 = self.make_s3()
+
+        key = None
+        if s3:
+            bucket = s3.get_bucket('embed.censusreporter.org')
+            key = Key(bucket, key_name)
+        return key
+
+    def write_json(self, s3_key, data):
+        s3_key.metadata['Content-Type'] = 'application/json'
+        s3_key.metadata['Content-Encoding'] = 'gzip'
+        s3_key.storage_class = 'REDUCED_REDUNDANCY'
+
+        # create gzipped version of json in memory
+        memfile = cStringIO.StringIO()
+        #memfile.write(data)
+        with gzip.GzipFile(filename=s3_key.key, mode='wb', fileobj=memfile) as gzip_data:
+            gzip_data.write(data)
+        memfile.seek(0)
+
+        # store static version on S3
+        s3_key.set_contents_from_file(memfile)
+        
+class MakeJSONView(View):
+    def post(self, request, *args, **kwargs):
+        post_data = self.request.POST
+        
+        if 'chart_data' in post_data:
+            chart_data = simplejson.loads(post_data['chart_data'], object_pairs_hook=OrderedDict)
+        if 'geography' in post_data:
+            geography = simplejson.loads(post_data['geography'], object_pairs_hook=OrderedDict)
+        if 'geo_metadata' in post_data:
+            geo_metadata = simplejson.loads(post_data['geo_metadata'], object_pairs_hook=OrderedDict)
+
+        if 'params' in post_data:
+            params = simplejson.loads(post_data['params'])
+        
+        # for now, assume we need all these things
+        if not (chart_data and geography and geo_metadata and params):
+            return render_json_to_response({'success': 'false'})
+        
+        path_to_make = params['chartDataID'].split('-')
+        data = {
+            'geography': geography,
+            'geo_metadata': geo_metadata,
+        }
+        
+        # bless you, http://stackoverflow.com/a/13688108/3204984
+        def nested_set(data, keys, value):
+            for key in keys[:-1]:
+                data = data.setdefault(key, {})
+            data[keys[-1]] = value
+
+        nested_set(data, path_to_make, chart_data)
+
+        chart_data_json = SafeString(simplejson.dumps(data, cls=LazyEncoder))
+        
+        key_name = '/1.0/data/charts/{0}/{1}-{2}.json'.format(params['releaseID'], params['geoID'], params['chartDataID'])
+        s3 = S3Conn()
+
+        try:
+            s3_key = s3.s3_key(key_name)
+        except:
+            s3_key = None
+
+        if s3_key and s3_key.exists():
+            pass
+        elif s3_key:
+            s3.write_json(s3_key, chart_data_json)
+        else:
+            logger.warn("Could not save to S3 because there was no connection to S3.")
+        
+        return render_json_to_response({'success': 'true'})
+
+
+        
 ## LOCAL DEV VERSION OF API ##
 
 class PlaceSearchJson(View):


### PR DESCRIPTION
**This needs review and conversation before merging!**

_The problem we are addressing:_ By enabling 2014 1-year data on the site, we will in many cases provide profile pages with a mix of 2014 and 2013 data, where the geography is big enough as a whole for 1-year data, but certain table universes fall below that threshhold. Our API's "latest" endpoint knows, in that case, to fall back to smaller releases, which for the next few months will mean dipping into 2013 data. Meanwhile, when we enable 2014 data, we would ​*also*​ be updating the cache dir in S3 from /2013 --> /2014. So the risk is that someone will be looking at a mixed-release profile page, which will be pulling data from /2014 JSON, and then decide to embed a chart that comes from 2013 data. The embed code knows the chart data comes from 2013, and so will look in /2013 for the data, with no guarantee that it exists.

This implementation:
* refactors our embed code to look for chart-specific JSON inside of release-specific directories in our S3 bucket. E.g. `1.0./data/charts/[RELEASE_KEY]/[GEO_ID]-[CHART_KEY].json`
* creates (if necessary) that chart-specific JSON whenever someone clicks "embed" next to a chart. That chart already knows what data it needs to build itself, so it fires a POST request at a new URL endpoint, `/make-json/charts/`, which builds a condensed version of our usual profile JSON, with only the data necessary for that specific chart. For example: https://embed.censusreporter.org.s3.amazonaws.com/1.0/data/charts/ACS_2013_1-year/16000US5367000-demographics-age-distribution_by_category.json
* continues to support old embed code. Previous embed querystrings do not contain the `releaseID` param, so the embed frame code falls back to previous data directories.
* leaves the chart-rendering code alone. The full-profile JSON used by old code and the chart-specific JSON used by the new code both have the same nested hierarchy, so the chart code method of drilling into the JSON obj to find the right dataset still works in either case.