### PR TITLE
Distinguish PR tables in list of table variations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Census Reporter
+Copyright (c) 2014-2016 Census Reporter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2016 Census Reporter
+Copyright (c) 2014 Census Reporter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -221,6 +221,10 @@ class TableDetailView(TemplateView):
                 if len(table_code) == 7:
                     tables[letter_code][table_code]['version_name'] = self.VARIANT_TRANSLATE_DICT[table_code.upper()[-1]]
 
+                # Puerto Rico tables have 8 characters; handle those names
+                if len(table_code) == 8:
+                    tables[letter_code][table_code]['version_name'] = "Puerto Rico"
+
         tabulation_data['table_versions'] = tables.pop(self.table_group, None)
         tabulation_data['related_tables'] = {
             'grid': tables,

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -221,9 +221,16 @@ class TableDetailView(TemplateView):
                 if len(table_code) == 7:
                     tables[letter_code][table_code]['version_name'] = self.VARIANT_TRANSLATE_DICT[table_code.upper()[-1]]
 
-                # Puerto Rico tables have 8 characters; handle those names
-                if len(table_code) == 8:
-                    tables[letter_code][table_code]['version_name'] = "Puerto Rico"
+                # Puerto Rico tables have "PR" at the end; handle those names
+                if table_code[-2:] == "PR":
+                    # if it's 8 characters, there are no iterations
+                    if len(table_code) == 8:
+                        tables[letter_code][table_code]['version_name'] = "Standard Table (Puerto Rico)"
+
+                    # otherwise, there are iterations for the PR tables
+                    else:
+                        tables[letter_code][table_code]['version_name'] = self.VARIANT_TRANSLATE_DICT[table_code.upper()[6]] + " (Puerto Rico)"
+
 
         tabulation_data['table_versions'] = tables.pop(self.table_group, None)
         tabulation_data['related_tables'] = {


### PR DESCRIPTION
Fix #154 by adding code to views.py to recognize and label PR tables. Tested on `B06001`. 