### PR TITLE
Handle tables with iterations but no base table

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Census Reporter
+Copyright (c) 2014-2016 Census Reporter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -247,17 +247,23 @@ class TableDetailView(TemplateView):
 
         return related_topic_pages
 
+
     def get_table_data(self, table_code):
         endpoint = settings.API_URL + '/2.0/table/latest/%s' % table_code
         r = requests.get(endpoint)
-        status_code = r.status_code
 
-        if status_code == 200:
+        if r.status_code == 400:
+            # Try adding an "A" to the table_code, in case an iteration exists
+            endpoint += 'A'
+            r = requests.get(endpoint)
+
+        if r.status_code == 200:
             return simplejson.loads(r.text, object_pairs_hook=OrderedDict)
-        elif status_code == 404 or status_code == 400:
+        if r.status_code == 404 or r.status_code == 400:
             raise ValueError("No table data for that table")
         else:
             raise Http404
+
 
     def get_context_data(self, *args, **kwargs):
         page_context = {

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -219,7 +219,15 @@ class TableDetailView(TemplateView):
         # * a grid with each table variant and which releases it's available for
         # * a list of each primary table, with its column metadata from the API
         for release in tabulation_data['tables_by_release']:
-            for table_code in tabulation_data['tables_by_release'][release]:
+            # Sort data by length to have all the PR tables at the end.
+            # Note that sorted() is guaranteed to be stable, per Python docs,
+            # meaning that keys that compare equal (are equal length) will 
+            # remain in the same relative order. Assuming they were alphabetical 
+            # before this, this is guaranteed to list tables as
+            # tableA, ... , tableI, tableAPR, ... , tableIPR.
+            sorted_data = sorted(tabulation_data['tables_by_release'][release],
+                                 key = lambda code: len(code))
+            for table_code in sorted_data:
                 # is this a B or C table?
                 letter_code = table_code.upper()[0]
                 tables[letter_code] = default_table_groups[letter_code]
@@ -242,7 +250,6 @@ class TableDetailView(TemplateView):
                     # otherwise, there are iterations for the PR tables
                     else:
                         tables[letter_code][table_code]['version_name'] = self.VARIANT_TRANSLATE_DICT[table_code.upper()[6]] + " (Puerto Rico)"
-
 
         tabulation_data['table_versions'] = tables.pop(self.table_group, None)
         tabulation_data['related_tables'] = {

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -247,7 +247,6 @@ class TableDetailView(TemplateView):
 
         return related_topic_pages
 
-
     def get_table_data(self, table_code):
         endpoint = settings.API_URL + '/2.0/table/latest/%s' % table_code
         r = requests.get(endpoint)
@@ -263,7 +262,6 @@ class TableDetailView(TemplateView):
             raise ValueError("No table data for that table")
         else:
             raise Http404
-
 
     def get_context_data(self, *args, **kwargs):
         page_context = {


### PR DESCRIPTION
If the table data request returns an error, we try making a request for what would be the first iteration. The remainder of the logic stays the same. Fixes #141 in that `.../tables/B06004/` now gives the user the page for `B06004A`