### PR TITLE
Fix incorrect table information on topic pages

### DIFF
--- a/censusreporter/apps/census/templates/topics/children.html
+++ b/censusreporter/apps/census/templates/topics/children.html
@@ -64,7 +64,7 @@
 </tr></thead>
 <tbody>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B05009' %}">B05009</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B05009' %}">B05009</a></strong></td>
 <td>Age and Nativity of Own Children in Families and Subfamilies by Number and Nativity of Parents</td>
 </tr>
 <tr>
@@ -184,7 +184,7 @@
 <td>Family Type by Presence of Own Children by Family Income</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B22002' %}">B22002</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B22002' %}">B22002</a></strong></td>
 <td>Receipt of Food Stamps/SNAP by Presence of Children by Household Type for Households</td>
 </tr>
 <tr>

--- a/censusreporter/apps/census/templates/topics/children.html
+++ b/censusreporter/apps/census/templates/topics/children.html
@@ -25,24 +25,12 @@
 <td>Household Type for Children in Households (Excluding Householders, Spouses, and Unmarried Partners)</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B09006' %}">B09006</a></strong></td>
-<td>Relationship to Householder for Children in Households</td>
-</tr>
-<tr>
 <td><strong><a href="{% url 'table_detail' 'B09008' %}">B09008</a><sup>‡</sup></strong></td>
 <td>Presence of Unmarried Partner of Householder by Household Type for Children in Households</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B09010' %}">B09010</a></strong></td>
 <td>Receipt of Supplemental Security Income (SSI), Cash Public Assistance Income, or Food Stamps/SNAP by Household Type for Children in Households</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B09016' %}">B09016</a><sup>‡</sup></strong></td>
-<td>Household Type (Including Living Alone) by Relationship</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B09017' %}">B09017</a></strong></td>
-<td>Relationship by Household Type (Including Living Alone) for the Population 65 Years and Over</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B09018' %}">B09018</a></strong></td>
@@ -114,10 +102,6 @@
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B10054' %}">B10054</a></strong></td>
 <td>Language and Ability to Speak English of Grandparents Living With Own Grandchildren by Responsibility for Own Grandchildren and Age of Grandparent</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B10055' %}">B10055</a></strong></td>
-<td>Disability Status of Grandparents Living With Own Grandchildren by Responsibility for Own Grandchildren and Age of Grandparent</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B10056' %}">B10056</a></strong></td>

--- a/censusreporter/apps/census/templates/topics/commute.html
+++ b/censusreporter/apps/census/templates/topics/commute.html
@@ -63,43 +63,43 @@
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08011' %}">B08011</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08011' %}">B08011</a></strong>
 </td>
 <td>Sex of Workers by Time Leaving Home to Go to Work</td>
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08012' %}">B08012</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08012' %}">B08012</a></strong>
 </td>
 <td>Sex of Workers by Travel Time to Work</td>
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08412' %}">B08412</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08412' %}">B08412</a></strong>
 </td>
 <td>Sex of Workers by Travel Time to Work for Workplace Geography</td>
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08602' %}">B08602</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08602' %}">B08602</a></strong>
 </td>
 <td>Time Arriving at Work From Home for Workplace Geography</td>
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08302' %}">B08302</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08302' %}">B08302</a></strong>
 </td>
 <td>Time Leaving Home to Go to Work</td>
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08303' %}">B08303</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08303' %}">B08303</a></strong>
 </td>
 <td>Travel Time to Work</td>
 </tr>
 <tr>
 <td>
-<strong><a href="{% url 'table_detail' 'B08603' %}">B08603</a></strong><sup>‡</sup>
+<strong><a href="{% url 'table_detail' 'B08603' %}">B08603</a></strong>
 </td>
 <td>Travel Time to Work for Workplace Geography</td>
 </tr>
@@ -124,7 +124,7 @@
 </tr></thead>
 <tbody>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08007' %}">B08007</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08007' %}">B08007</a></strong></td>
 <td>Sex of Workers by Place of Work--State and County Level</td>
 </tr>
 <tr>
@@ -140,11 +140,11 @@
 <td>Place of Work for Workers 16 Years and Over--Metropolitan Statistical Area Level</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08017' %}">B08017</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08017' %}">B08017</a></strong></td>
 <td>Place of Work for Workers 16 Years and Over--Micropolitan Statistical Area Level</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08018' %}">B08018</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08018' %}">B08018</a></strong></td>
 <td>Place of Work for Workers 16 Years and Over--not Metropolitan or Micropolitan Statistical Area Level</td>
 </tr>
 </tbody>
@@ -206,7 +206,7 @@
 <td>Median Age by Means of Transportation to Work</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08105' %}">B08105</a><sup>ª‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08105' %}">B08105</a><sup>ª</sup></strong></td>
 <td>Means of Transportation to Work (racial iterations)</td>
 </tr>
 <tr>
@@ -258,7 +258,7 @@
 <td>Aggregate Travel Time to Work (In Minutes) of Workers by Means of Transportation to Work</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08137' %}">B08137</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08137' %}">B08137</a></strong></td>
 <td>Means of Transportation to Work by Tenure</td>
 </tr>
 <tr>
@@ -282,7 +282,7 @@
 <td>Median Age by Means of Transportation to Work for Workplace Geography</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08505' %}">B08505</a><sup>ª‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08505' %}">B08505</a></strong></td>
 <td>Means of Transportation to Work for Workplace Geography (racial iterations)</td>
 </tr>
 <tr>
@@ -330,7 +330,7 @@
 <td>Aggregate Travel Time to Work (In Minutes) of Workers by Means of Transportation to Work for Workplace Geography</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08537' %}">B08537</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08537' %}">B08537</a></strong></td>
 <td>Means of Transportation to Work by Tenure for Workplace Geography</td>
 </tr>
 <tr>

--- a/censusreporter/apps/census/templates/topics/employment.html
+++ b/censusreporter/apps/census/templates/topics/employment.html
@@ -63,10 +63,6 @@
 <td>Presence of Own Children by Age of Own Children by Employment Status for Females 20 to 64 Years</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B23004' %}">B23004</a><sup>‡</sup></strong></td>
-<td>Work Status by Age by Employment Status for the Civilian Population 65 Years and Over</td>
-</tr>
-<tr>
 <td><strong><a href="{% url 'table_detail' 'B23006' %}">B23006</a></strong></td>
 <td>Educational Attainment by Employment Status for the Population 25 to 64 Years</td>
 </tr>
@@ -103,10 +99,6 @@
 <td>Sex by Work Status by Usual Hours Worked Per Week by Weeks Worked for the Population 16 to 64 Years</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B23023' %}">B23023</a><sup>‡</sup></strong></td>
-<td>Sex by Disability Status by Work Status by Usual Hours Worked Per Week by Weeks Worked for the Population 16 to 64 Years</td>
-</tr>
-<tr>
 <td><strong><a href="{% url 'table_detail' 'B23024' %}">B23024</a></strong></td>
 <td>Poverty Status by Disability Status by Employment Status for the Population 20 to 64 Years</td>
 </tr>
@@ -140,7 +132,7 @@
 <p>In different tables, these groups are subdivided to varying depths. For <strong><a href="{% url 'table_detail' 'B24010' %}">B24010</a>/<a href="{% url 'table_detail' 'B24020' %}">B24020</a></strong>, there are a total of 150 columns for each of male and female workers. These columns are nested so that some values represent the total of columns below them. If you do your own summing, Be careful not to double-count by mixing columns of different depths.</p>
 <p><strong>Important:</strong> the ACS 5-year release does not include the <strong><a href="{% url 'table_detail' 'B24010' %}">B24010</a>/<a href="{% url 'table_detail' 'B24020' %}">B24020</a></strong> tables. To analyze occupation data for smaller geographies, you must use the <strong><a href="{% url 'table_detail' 'C24010' %}">C24010</a>/<a href="{% url 'table_detail' 'C24020' %}">C24020</a></strong> tables. These have the same five high level groups, but are broken down into only 35 columns for each of male and female workers.</p>
 <h3 id="industry">Industry</h3>
-<p>In addition to the work Americans do, the ACS counts the industries in which they do that work. In these tables, there are 13 top level categories for industries. For <strong><a href="{% url 'table_detail' 'B02030' %}">B02030</a></strong> and <strong><a href="{% url 'table_detail' 'B02040' %}">B02040</a></strong>, these are further subdivided into a total of 103 industries. For other tables, the industries generally don't go that deep. As with occupations, be careful not to double-count if you are doing your own summing.</p>
+<p>In addition to the work Americans do, the ACS counts the industries in which they do that work. In these tables, there are 13 top level categories for industries. As with occupations, be careful not to double-count if you are doing your own summing.</p>
 <p>These are the 13 top-level industries:</p>
 <ul>
 <li>Agriculture, forestry, fishing and hunting, and mining</li>

--- a/censusreporter/apps/census/templates/topics/families.html
+++ b/censusreporter/apps/census/templates/topics/families.html
@@ -175,7 +175,7 @@ journalists researching same-sex parents are advised to consult experts. See <a 
 <td>Family Type by Presence of Own Children Under 18 Years by Family Income in the Past 12 Months (In 2012 Inflation-adjusted Dollars)</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B22007' %}">B22007</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B22007' %}">B22007</a></strong></td>
 <td>Receipt of Food Stamps/SNAP in the Past 12 Months by Family Type by Number of Workers in Family in the Past 12 Months</td>
 </tr>
 <tr>

--- a/censusreporter/apps/census/templates/topics/migration.html
+++ b/censusreporter/apps/census/templates/topics/migration.html
@@ -102,11 +102,11 @@
 <td>Geographical Mobility — Current Residence--Metropolitan Statistical Area Level</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B07202' %}">B07202</a><sup>‡§</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B07202' %}">B07202</a><sup>§</sup></strong></td>
 <td>Geographical Mobility — Current Residence--Micropolitan Statistical Area Level</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B07203' %}">B07203</a><sup>‡§</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B07203' %}">B07203</a><sup>§</sup></strong></td>
 <td>Geographical Mobility — Current Residence--not Metropolitan or Micropolitan Statistical Area Level</td>
 </tr>
 <tr>
@@ -134,7 +134,7 @@
 <td>Geographical Mobility by Citizenship — Residence 1 Year Ago</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B07408' %}">B07408</a><sup>‡§</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B07408' %}">B07408</a><sup>§</sup></strong></td>
 <td>Geographical Mobility by Marital Status — Residence 1 Year Ago</td>
 </tr>
 <tr>

--- a/censusreporter/apps/census/templates/topics/poverty.html
+++ b/censusreporter/apps/census/templates/topics/poverty.html
@@ -173,40 +173,8 @@ Some table names have been simplified. References to poverty status/level or rec
 <td>Poverty Status by School Enrollment by Level of School for the Population 3 Years and Over</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B15004' %}">B15004</a></strong></td>
-<td>Poverty Status by Sex by Educational Attainment for the Population 25 Years and Over</td>
-</tr>
-<tr>
 <td><strong><a href="{% url 'table_detail' 'B16009' %}">B16009</a><sup>†</sup></strong></td>
 <td>Poverty Status by Age by Language Spoken at Home for the Population 5 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18030' %}">B18030</a><sup>†</sup></strong></td>
-<td>Disability Status by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 5 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18031' %}">B18031</a><sup>†</sup></strong></td>
-<td>Sensory Disability by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 5 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18032' %}">B18032</a><sup>†</sup></strong></td>
-<td>Physical Disability by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 5 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18033' %}">B18033</a><sup>†</sup></strong></td>
-<td>Mental Disability by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 5 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18034' %}">B18034</a><sup>†</sup></strong></td>
-<td>Self-care Disability by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 5 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18035' %}">B18035</a><sup>†</sup></strong></td>
-<td>Go-outside-home Disability by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 16 Years and Over</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B18036' %}">B18036</a><sup>†</sup></strong></td>
-<td>Employment Disability by Sex by Age by Poverty Status for the Civilian Noninstitutionalized Population 16 to 64 Years</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B18130' %}">B18130</a><sup>†</sup></strong></td>
@@ -215,10 +183,6 @@ Some table names have been simplified. References to poverty status/level or rec
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B18131' %}">B18131</a><sup>†</sup></strong></td>
 <td>Age by Ratio of Income to Poverty Level by Disability Status and Type</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B21006' %}">B21006</a><sup>†</sup></strong></td>
-<td>Age by Veteran Status by Poverty Status by Disability Status for the Civilian Population 18 Years and Over</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B21007' %}">B21007</a><sup>†</sup></strong></td>
@@ -231,10 +195,6 @@ Some table names have been simplified. References to poverty status/level or rec
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B22005' %}">B22005</a><sup>ª</sup></strong></td>
 <td>Receipt of Food Stamps/SNAP by Race of Householder</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B23005' %}">B23005</a></strong></td>
-<td>Poverty Status by Disability Status by Employment Status for the Population 20 to 64 Years</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B23024' %}">B23024</a></strong></td>

--- a/censusreporter/apps/census/templates/topics/poverty.html
+++ b/censusreporter/apps/census/templates/topics/poverty.html
@@ -137,7 +137,7 @@ Some table names have been simplified. References to poverty status/level or rec
 </tr></thead>
 <tbody>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B05010' %}">B05010</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B05010' %}">B05010</a></strong></td>
 <td>Ratio of Income to Poverty Level by Nativity of Children Under 18 Years in Families and Subfamilies by Living Arrangements and Nativity of Parents</td>
 </tr>
 <tr>
@@ -153,11 +153,11 @@ Some table names have been simplified. References to poverty status/level or rec
 <td>Geographical Mobility in the Past Year by Poverty Status for Residence 1 Year Ago in the United States</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08122' %}">B08122</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08122' %}">B08122</a></strong></td>
 <td>Means of Transportation to Work by Poverty Status</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B08522' %}">B08522</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B08522' %}">B08522</a></strong></td>
 <td>Means of Transportation to Work by Poverty Status for Workplace Geography</td>
 </tr>
 <tr>
@@ -169,23 +169,23 @@ Some table names have been simplified. References to poverty status/level or rec
 <td>Women 15 to 50 Years Who Had a Birth in the Past 12 Months by Marital Status and Poverty Status</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B14006' %}">B14006</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B14006' %}">B14006</a></strong></td>
 <td>Poverty Status by School Enrollment by Level of School for the Population 3 Years and Over</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B16009' %}">B16009</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B16009' %}">B16009</a></strong></td>
 <td>Poverty Status by Age by Language Spoken at Home for the Population 5 Years and Over</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B18130' %}">B18130</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B18130' %}">B18130</a></strong></td>
 <td>Age by Disability Status by Poverty Status</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B18131' %}">B18131</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B18131' %}">B18131</a></strong></td>
 <td>Age by Ratio of Income to Poverty Level by Disability Status and Type</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B21007' %}">B21007</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B21007' %}">B21007</a></strong></td>
 <td>Age by Veteran Status by Poverty Status by Disability Status for the Civilian Population 18 Years and Over</td>
 </tr>
 <tr>
@@ -201,15 +201,15 @@ Some table names have been simplified. References to poverty status/level or rec
 <td>Poverty Status by Disability Status by Employment Status for the Population 20 to 64 Years</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B27016' %}">B27016</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B27016' %}">B27016</a></strong></td>
 <td>Health Insurance Coverage Status and Type by Ratio of Income to Poverty Level by Age</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B27017' %}">B27017</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B27017' %}">B27017</a></strong></td>
 <td>Private Health Insurance by Ratio of Income to Poverty Level by Age</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B27018' %}">B27018</a><sup>†</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B27018' %}">B27018</a></strong></td>
 <td>Public Health Insurance by Ratio of Income to Poverty Level by Age</td>
 </tr>
 </tbody>

--- a/censusreporter/apps/census/templates/topics/public-assistance.html
+++ b/censusreporter/apps/census/templates/topics/public-assistance.html
@@ -19,7 +19,7 @@
 <td>Receipt of Food Stamps/SNAP by Presence of People 60 Years and Over for Households</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B22002' %}">B22002</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B22002' %}">B22002</a></strong></td>
 <td>Receipt of Food Stamps/SNAP by Presence of Children by Household Type for Households</td>
 </tr>
 <tr>
@@ -31,7 +31,7 @@
 <td>Receipt of Food Stamps/SNAP by Race of Householder</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B22007' %}">B22007</a><sup>‡</sup></strong></td>
+<td><strong><a href="{% url 'table_detail' 'B22007' %}">B22007</a></strong></td>
 <td>Receipt of Food Stamps/SNAP by Family Type by Number of Workers in Family</td>
 </tr>
 <tr>

--- a/censusreporter/apps/census/templates/topics/public-assistance.html
+++ b/censusreporter/apps/census/templates/topics/public-assistance.html
@@ -27,10 +27,6 @@
 <td>Receipt of Food Stamps/SNAP by Poverty Status for Households</td>
 </tr>
 <tr>
-<td><strong><a href="{% url 'table_detail' 'B22004' %}">B22004</a></strong></td>
-<td>Receipt of Food Stamps by Disability Status for Households</td>
-</tr>
-<tr>
 <td><strong><a href="{% url 'table_detail' 'B22005' %}">B22005</a><sup>†</sup></strong></td>
 <td>Receipt of Food Stamps/SNAP by Race of Householder</td>
 </tr>

--- a/censusreporter/apps/census/templates/topics/race_hispanic.html
+++ b/censusreporter/apps/census/templates/topics/race_hispanic.html
@@ -123,15 +123,15 @@ Here is the complete listing of tables which the Census Bureau classifies as dir
             <td>Detailed Race</td>
         </tr>
         <tr>
-            <td><strong><a href="{% url 'table_detail' 'B02005' %}">B02005</a><sup>‡</sup></strong></td>
+            <td><strong><a href="{% url 'table_detail' 'B02005' %}">B02005</a></strong></td>
             <td>American Indian and Alaska Native Alone for Selected Tribal Groupings</td>
         </tr>
         <tr>
-            <td><strong><a href="{% url 'table_detail' 'B02006' %}">B02006</a><sup>‡</sup></strong></td>
+            <td><strong><a href="{% url 'table_detail' 'B02006' %}">B02006</a></strong></td>
             <td>Asian Alone by Selected Groups</td>
         </tr>
         <tr>
-            <td><strong><a href="{% url 'table_detail' 'B02007' %}">B02007</a><sup>‡</sup></strong></td>
+            <td><strong><a href="{% url 'table_detail' 'B02007' %}">B02007</a></strong></td>
             <td>Native Hawaiian and Other Pacific Islander Alone by Selected Groups</td>
         </tr>
         <tr>
@@ -235,42 +235,42 @@ In addition to the tables specifically about race and Latino origin, many other 
         </tr>
     </thead>
     <tbody>
-        <tr><td><strong><a href="{% url 'table_detail' 'B01001' %}">B01001</a><sup>‡</sup></strong></td><td>Sex by Age</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B01001' %}">B01001</a></strong></td><td>Sex by Age</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B01002' %}">B01002</a></strong></td><td>Median Age by Sex</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B05003' %}">B05003</a><sup>‡</sup></strong></td><td>Sex by Age by Nativity and Citizenship Status</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B06004' %}">B06004</a><sup>§ª</sup></strong></td><td>Place of Birth</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B07004' %}">B07004</a><sup>§ª</sup></strong></td><td>Geographical Mobility in the Past Year for Current Residence</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B07404' %}">B07404</a><sup>§ª</sup></strong></td><td>Geographical Mobility in the Past Year for Residence 1 Year Ago</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B08105' %}">B08105</a><sup>‡ª</sup></strong></td><td>Means of Transportation to Work</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B08505' %}">B08505</a><sup>‡ª</sup></strong></td><td>Means of Transportation to Work for Workplace Geography</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B08105' %}">B08105</a><sup>ª</sup></strong></td><td>Means of Transportation to Work</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B08505' %}">B08505</a><sup>ª</sup></strong></td><td>Means of Transportation to Work for Workplace Geography</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B10051' %}">B10051</a></strong></td><td>Grandparents Living With Own Grandchildren Under 18 Years by Responsibility for Own Grandchildren by Presence of Parent of Grandchildren and Age of Grandparent</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B11001' %}">B11001</a><sup>‡</sup></strong></td><td>Household Type (Including Living Alone)</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B11002' %}">B11002</a><sup>‡</sup></strong></td><td>Household Type by Relatives and Nonrelatives for Population in Households</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B12002' %}">B12002</a><sup>‡</sup></strong></td><td>Sex by Marital Status by Age for the Population 15 Years and Over</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B11001' %}">B11001</a></strong></td><td>Household Type (Including Living Alone)</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B11002' %}">B11002</a></strong></td><td>Household Type by Relatives and Nonrelatives for Population in Households</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B12002' %}">B12002</a></strong></td><td>Sex by Marital Status by Age for the Population 15 Years and Over</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B12007' %}">B12007</a></strong></td><td>Median Age at First Marriage</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B13002' %}">B13002</a></strong></td><td>Women 15 to 50 Years Who Had a Birth by Marital Status and Age</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B14007' %}">B14007</a><sup>‡</sup></strong></td><td>School Enrollment by Detailed Level of School for the Population 3 Years and Over</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B14007' %}">B14007</a></strong></td><td>School Enrollment by Detailed Level of School for the Population 3 Years and Over</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B15002' %}">B15002</a><sup>‡</sup></strong></td><td>Sex by Educational Attainment for the Population 25 Years and Over</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B16005' %}">B16005</a></strong></td><td>Nativity by Language Spoken at Home by Ability to Speak English for the Population 5 Years and Over</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B16006' %}">B16006</a><sup>‡</sup></strong></td><td>Language Spoken at Home by Ability to Speak English for the Population 5 Years and Over (Hispanic or Latino)</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B17001' %}">B17001</a><sup>‡</sup></strong></td><td>Poverty Status by Sex by Age</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B17010' %}">B17010</a><sup>‡</sup></strong></td><td>Poverty Status of Families by Family Type by Presence of Related Children Under 18 Years by Age of Related Children</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B17020' %}">B17020</a><sup>‡ª</sup></strong></td><td>Poverty Status by Age</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B17020' %}">B17020</a><sup>ª</sup></strong></td><td>Poverty Status by Age</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B18101' %}">B18101</a></strong></td><td>Sex by Age by Disability Status</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B19001' %}">B19001</a><sup>‡</sup></strong></td><td>Household Income</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B19001' %}">B19001</a</strong></td><td>Household Income</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B19013' %}">B19013</a></strong></td><td>Median Household Income</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B19025' %}">B19025</a></strong></td><td>Aggregate Household Income</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B19037' %}">B19037</a><sup>‡</sup></strong></td><td>Age of Householder by Household Income</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B19101' %}">B19101</a><sup>‡</sup></strong></td><td>Family Income</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B19037' %}">B19037</a></strong></td><td>Age of Householder by Household Income</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B19101' %}">B19101</a></strong></td><td>Family Income</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B19113' %}">B19113</a></strong></td><td>Median Family Income</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B19202' %}">B19202</a></strong></td><td>Median Nonfamily Household Income</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B19301' %}">B19301</a></strong></td><td>Per Capita Income</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B19313' %}">B19313</a></strong></td><td>Aggregate Income</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B20005' %}">B20005</a><sup>‡</sup></strong></td><td>Sex by Work Experience by Earnings</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B20005' %}">B20005</a></strong></td><td>Sex by Work Experience by Earnings</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B20017' %}">B20017</a></strong></td><td>Median Earnings by Sex by Work Experience With Earnings</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B21001' %}">B21001</a><sup>‡</sup></strong></td><td>Sex by Age by Veteran Status for the Civilian Population 18 Years and Over</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B21001' %}">B21001</a></strong></td><td>Sex by Age by Veteran Status for the Civilian Population 18 Years and Over</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B22005' %}">B22005</a><sup>ª</sup></strong></td><td>Receipt of Food Stamps/SNAP by Race of Householder</td></tr>
-        <tr><td><strong><a href="{% url 'table_detail' 'B23002' %}">B23002</a><sup>‡ª</sup></strong></td><td>Sex by Age by Employment Status</td></tr>
+        <tr><td><strong><a href="{% url 'table_detail' 'B23002' %}">B23002</a><sup>ª</sup></strong></td><td>Sex by Age by Employment Status</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B24010' %}">B24010</a><sup>‡</sup></strong></td><td>Sex by Occupation for the Civilian Employed Population 16 Years and Over</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B25003' %}">B25003</a></strong></td><td>Tenure</td></tr>
         <tr><td><strong><a href="{% url 'table_detail' 'B25014' %}">B25014</a></strong></td><td>Tenure by Occupants Per Room</td></tr>

--- a/censusreporter/apps/census/templates/topics/seniors.html
+++ b/censusreporter/apps/census/templates/topics/seniors.html
@@ -3,14 +3,13 @@
 {% block content %}
 <section id="topic-overview">
     {% include "topics/_question_aside.html" %}    
-<p>It is more trouble than you might guess to get a simple count of the number of people 65 and older in a geography. The most direct route is to take a table which has a <span class="glossary-term">universe</span> 'Population 65 Years and Over' and use the value from the first (total) column. As of the 2012 ACS releases, the preferred table for this is <strong><a href="{% url 'table_detail' 'B09020' %}">B09020</a></strong>. This table was introduced in 2008 to replace <strong><a href="{% url 'table_detail' 'B09017' %}">B09017</a></strong>, and with the 2012 release, <strong><a href="{% url 'table_detail' 'B09020' %}">B09020</a></strong> is available in all of the 1-, 3- and 5-year releases.</p>
+<p>It is more trouble than you might guess to get a simple count of the number of people 65 and older in a geography. The most direct route is to take a table which has a <span class="glossary-term">universe</span> 'Population 65 Years and Over' and use the value from the first (total) column. As of the 2012 ACS releases, the preferred table for this is <strong><a href="{% url 'table_detail' 'B09020' %}">B09020</a></strong>. With the 2012 release, <strong><a href="{% url 'table_detail' 'B09020' %}">B09020</a></strong> is available in all of the 1-, 3- and 5-year releases.</p>
 <p>Otherwise, here are Census tables pertinent to senior citizens:</p>
 <h3 id="b09020-senior-citizen-living-arrangements">B09020: Senior citizen living arrangements</h3>
-<p>Table <strong><a href="{% url 'table_detail' 'B09020' %}">B09020</a></strong> can be used to determine how many citizens 65 years or older live alone, live with family members or non-relatives, or live in assisted living or other institutions (what the census calls "Group Quarters"). Earlier ACS releases had a similar table, <strong><a href="{% url 'table_detail' 'B09017' %}">B09017</a></strong> which is identical, except that the current table counts citizens who are the "parent-in-law" of the <span class="glossary-term">householder</span> separately, while the old table included that relationship with "other relatives."</p>
+<p>Table <strong><a href="{% url 'table_detail' 'B09020' %}">B09020</a></strong> can be used to determine how many citizens 65 years or older live alone, live with family members or non-relatives, or live in assisted living or other institutions (what the census calls "Group Quarters"). This table counts citizens who are the "parent-in-law" of the <span class="glossary-term">householder</span> separately, while that relationship was previously included with "other relatives."</p>
 <h3 id="b11007-households-by-presence-of-senior-citizens">B11007: Households by presence of senior citizens</h3>
 <p>Table <strong><a href="{% url 'table_detail' 'B11007' %}">B11007</a></strong> counts households instead of individual people. It is another way to identify the number of households with seniors living alone, compared to households with seniors living with other people, family or non-family.</p>
 <h3 id="b23004-and-c23004-working-seniors">B23004 and C23004: Working seniors</h3>
-<p>Use table <strong><a href="{% url 'table_detail' 'B23004' %}">B23004</a></strong> for detailed information on working senior citizens. Data is broken down by age (65-74 years old and 75 and older), and whether they worked in the previous 12 months before completing the survey, whether they were still working or unemployed.</p>
 <p>Table <strong><a href="{% url 'table_detail' 'C23004' %}">C23004</a></strong> is only available in the 1- and 3-year ACS releases. It provides a simpler view of this data, with no age breakdown and then whether the person was working or trying to work at the time of completing the survey, retired, or long-term unemployed.</p>
 <h2 id="grandparents">Grandparents</h2>
 <p>The ACS has many tables providing various information about cases where grandparents and grandchildren live together. In various combinations, these tables provide data on the grandparent's responsibility for the grandchildren, the presence of the grandchildren's parent in the home, the employment, disability, poverty and marital status of the grandparents, and information about the housing itself: how long the grandparents have lived in their home, how many housing units are in the home, and more.</p>
@@ -54,10 +53,6 @@
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B10054' %}">B10054</a></strong></td>
 <td>Language and Ability to Speak English of Grandparents Living With Own Grandchildren by Responsibility for Own Grandchildren and Age of Grandparent</td>
-</tr>
-<tr>
-<td><strong><a href="{% url 'table_detail' 'B10055' %}">B10055</a></strong></td>
-<td>Disability Status of Grandparents Living With Own Grandchildren by Responsibility for Own Grandchildren and Age of Grandparent</td>
 </tr>
 <tr>
 <td><strong><a href="{% url 'table_detail' 'B10056' %}">B10056</a></strong></td>

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -166,15 +166,23 @@ class TableDetailView(TemplateView):
                         reverse('table_detail', args=(table_argument.upper(),))
                     )
 
-        # check if table code doesn't exist but has iterations; if so, redirect
-        # to the page for the first iteration
+        # Check if core table doesn't exist, but has iterations; if so, 
+        # redirect to the first iteration.
+        new_table_argument = table_argument + 'A'
+
+        # If the table being requested is a PR table, and it doesn't exist
+        # but the iterations do, then we want the alternate endpoint to be 
+        # B#####APR, not B#####PRA
+        if table_argument[6:8] == 'PR':
+            new_table_argument = table_argument[:6] + 'APR'
+
         endpoint_1 = settings.API_URL + '/2.0/table/latest/%s' % table_argument
-        endpoint_2 = settings.API_URL + '/2.0/table/latest/%sA' % table_argument
+        endpoint_2 = settings.API_URL + '/2.0/table/latest/%s' % new_table_argument
 
         if (requests.get(endpoint_1).status_code == 400
         and requests.get(endpoint_2).status_code == 200):
             return HttpResponseRedirect(
-                reverse('table_detail', args = (table_argument + 'A',))
+                reverse('table_detail', args = (new_table_argument,))
             )
 
         self.table_code = table_argument

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -196,7 +196,7 @@ class TableDetailView(TemplateView):
         r = requests.get(endpoint)
         status_code = r.status_code
 
-        # make sure we've requeste a legit tabulation code
+        # make sure we've requested a legit tabulation code
         if status_code == 200:
             tabulation_data = simplejson.loads(r.text, object_pairs_hook=OrderedDict)
         elif status_code == 404 or status_code == 400:
@@ -301,7 +301,7 @@ class TableDetailView(TemplateView):
 
         if r.status_code == 200:
             return simplejson.loads(r.text, object_pairs_hook=OrderedDict)
-        if r.status_code == 404 or r.status_code == 400:
+        if r.status_code == 400:
             raise ValueError("No table data for that table")
         else:
             raise Http404


### PR DESCRIPTION
This fixes #174, #176, and #185. I ran a Python script to scrape each topic page and check the tables on it to see if they actually exist. Similarly, it checked the annotations next to the tables (denoting things like collapsed table or iterations) to see if those were accurate.

Those that were not accurate are corrected by this PR.