### PR TITLE
Remove junk in schema.org JSON

### DIFF
--- a/censusreporter/apps/census/templates/_base.html
+++ b/censusreporter/apps/census/templates/_base.html
@@ -25,7 +25,7 @@
           {
             "@context": "http://schema.org",
             "@type": "Organization",
-            "name": "Census Reporter",!-- --
+            "name": "Census Reporter",
             "url": "https://censusreporter.org",
             "logo": "https://censusreporter.org/static/img/logo.png",
             "sameAs": [


### PR DESCRIPTION
We noticed CensusReporter.org is hard to find in SERPs, so I did some poking.

This pull removes errant chars in schema.org JSON that may be [interfering with search indexing](https://search.google.com/structured-data/testing-tool#url=http%3A%2F%2Fcensusreporter.org), especially in Google. 

Would recommend asking Google to [recrawl via Search Console](https://support.google.com/webmasters/answer/6065812?hl=en) after merge.

Thanks, we're big fans of the project here in Philly!
