### PR TITLE
Redirect to HTTPS

### DIFF
--- a/server/nginx.site.template
+++ b/server/nginx.site.template
@@ -8,6 +8,10 @@ server {
     set_real_ip_from   192.168.0.0/16;
     real_ip_recursive on;
 
+    if ($scheme = http) {
+        return 301 https://$server_name$request_uri;
+    }
+
     location / {
         include proxy_params;
         proxy_pass http://unix:%(project_path)s/%(domainname)s.sock;
@@ -29,5 +33,5 @@ server {
     listen 80;
     server_name censusreporter.com www.censusreporter.com www.censusreporter.org;
 
-    return 301 $scheme://censusreporter.org$request_uri;
+    return 301 https://censusreporter.org$request_uri;
 }


### PR DESCRIPTION
Uses http://serverfault.com/questions/250476/how-to-force-or-redirect-to-ssl-in-nginx to redirect `http` requests to `https`.