### PR TITLE
Update iframe.html to allow printing embedded charts

### DIFF
--- a/censusreporter/apps/census/static/iframe.html
+++ b/censusreporter/apps/census/static/iframe.html
@@ -42,6 +42,10 @@
                 padding-bottom: .5em !important;
             }
         }
+        @media only print {
+            -webkit-print-color-adjust: exact;
+            color-adjust: exact;
+        }
         </style>
         <!-- local patched version of r2d3 handles percentage widths, HTML overlays -->
         <!--[if lte IE 8]>


### PR DESCRIPTION
this fix allows PDFs/printed charts that have background-colored elements to show up.