### PR TITLE
remove obsolete javascript that dings our lighthouse score

### DIFF
--- a/censusreporter/apps/census/static/iframe.html
+++ b/censusreporter/apps/census/static/iframe.html
@@ -4,7 +4,6 @@
         <base target="_parent" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <link rel="stylesheet" href="css/charts.css" id="chart-styles">
-        <script src="//cdn.jsdelivr.net/g/modernizr@2.7,respond@1.4"></script>
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/censusreporter/apps/census/static/iframe_distribution_chart.html
+++ b/censusreporter/apps/census/static/iframe_distribution_chart.html
@@ -4,7 +4,7 @@
         <base target="_parent" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <link rel="stylesheet" href="https://s3.amazonaws.com/embed.censusreporter.org/1.0/css/charts.css" id="chart-styles">
-        <script src="//cdn.jsdelivr.net/g/modernizr@2.7,respond@1.4"></script>
+        <script src="//cdn.jsdelivr.net/g/respond@1.4"></script>
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/censusreporter/apps/census/templates/_base.html
+++ b/censusreporter/apps/census/templates/_base.html
@@ -29,11 +29,9 @@
 
         ]
     </script>
-    {% block head_javascript %}
-    <script src="//cdn.jsdelivr.net/g/modernizr@2.7,respond@1.4"></script>
     {% block head_javascript_extra %}
     <script src='https://api.tiles.mapbox.com/mapbox.js/v2.2.2/mapbox.js'></script>
-    {% endblock %} {% endblock %}
+    {% endblock %}
     <!-- Begin Google Analytics -->
     <script>
         (function(i, s, o, g, r, a, m) {


### PR DESCRIPTION
We have really terrible Lighthouse scores. I'm going to try to chip away at some of the problems.  First, we were loading some things from jsdeliver.net which were about supporting very old browsers, and we no longer need them. So, gone.