### PR TITLE
Update code blocks with easier to copy and run cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,46 +32,46 @@ Census Reporter is an open-source project, so not only is the data free to use, 
 Here's what you need to know to get a local version of Census Reporter up and running. These instructions assume you're using <a href="http://virtualenv.readthedocs.org/en/latest/">virtualenv</a> and <a href="http://virtualenvwrapper.readthedocs.org/en/latest/">virtualenvwrapper</a> to manage your development environments.
 
 First, clone this repository to your machine and move into your new project directory:
-
-    >> git clone git@github.com:censusreporter/censusreporter.git
-    >> cd <your cloned repo dir>
-
+~~~
+   git clone https://github.com/censusreporter/censusreporter censusreporter &&
+   cd censusreporter
+~~~
 Create the virtual environment for your local project, activate it and install the required libraries:
-
-    >> mkvirtualenv census --no-site-packages
-    >> workon census
-    >> pip install -r requirements.txt
-
+~~~
+   mkvirtualenv census --no-site-packages &&
+   workon census &&
+   pip install -r requirements.txt
+~~~
 With your development environment still active, make sure it has the path settings it will need:
-
-    >> add2virtualenv ./censusreporter
-    >> add2virtualenv ./censusreporter/apps
-
+~~~
+   add2virtualenv ./censusreporter &&
+   add2virtualenv ./censusreporter/apps
+~~~
 And make sure your development environment knows the proper DJANGO_SETTINGS_MODULE by creating a `postactivate` script ...
-
-    >> cdvirtualenv bin
-    >> touch postactivate
-
+~~~
+   cdvirtualenv bin &&
+   touch postactivate
+~~~
 ... and then using your favorite editor to add these two lines to your new `postactivate` script:
 
     export DJANGO_SETTINGS_MODULE='config.dev.settings'
     echo "DJANGO_SETTINGS_MODULE set to $DJANGO_SETTINGS_MODULE"
 
 Save and close the file. Reactivate your development environment so `postactivate` gets triggered, then fire up your local Census Reporter:
-
-    >> deactivate
-    >> workon census
-    >> cd <your cloned repo dir>
-    >> python manage.py runserver
-
+~~~
+   deactivate &&
+   workon census &&
+   cd censusreporter &&
+   python manage.py runserver
+~~~
 Hurray! Your local copy of Census Reporter will be hitting our production data sources, so you should be able to search and browse just like you would on the live website. If you'd like to go a step further, you can <a href="https://github.com/censusreporter/census-api">run the API locally</a>, and even <a href="http://censusreporter.tumblr.com/post/73727555158/easier-access-to-acs-data">load the entire Postgres database locally</a>, as well. But if you're primarily interested in adding features to the Census Reporter website or just seeing how it works, the instructions above should get you going.
 
 **Note** for people who wish to develop for Census Reporter
 
 If you are running the django server from within the vagrant box, provide the localhost explicitly 
-
-    >> python manage.py runserver 0.0.0.0:8000
-
+~~~
+   python manage.py runserver 0.0.0.0:8000
+~~~
 The application can now be accessed via localhost:8000 on your browser
 
 Getting data from our API (the basics)


### PR DESCRIPTION
1. Removed >> so code runs when copying
2. Added && so code runs when copying
3. Changed <your cloned repo dir> to censusreporter
since most users will retain the same folder name.
4. Added ~~~ around upper code blocks.
Tab indent alone did not invoke code block style.