### PR TITLE
Migrate to Django 4.2 and boto3, bump six and lxml

### DIFF
--- a/cache_clearer.py
+++ b/cache_clearer.py
@@ -9,8 +9,7 @@
 
    .
 """
-from boto.s3.connection import S3Connection, OrdinaryCallingFormat
-from boto.s3.key import Key
+import boto3
 from gzip import GzipFile
 from cStringIO import StringIO
 import json
@@ -37,12 +36,15 @@ def releases(j_string):
   pat = re.compile('ACS (.+?)-year')
   return set(pat.findall(j_string))
 
-def get_key(b,geoid):
-    key_path = '1.0/data/profiles/{}/{}.json'.format(CACHE_KEY_YEAR,geoid)
-    return b.get_key(key_path)
+def get_key(s3_client, bucket_name, geoid):
+    key_path = f'1.0/data/profiles/{CACHE_KEY_YEAR}/{geoid}.json'
+    return s3_client.get_object(Bucket='embed.censusreporter.org', Key=key_path)
 
-s3 = S3Connection(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, calling_format=OrdinaryCallingFormat())
-bucket = s3.get_bucket('embed.censusreporter.org')
+s3_client = boto3.client(
+    's3',
+    aws_access_key_id=AWS_ACCESS_KEY_ID,
+    aws_secret_access_key=AWS_SECRET_ACCESS_KEY
+)
 
 deleted = []
 

--- a/censusreporter/apps/census/urls.py
+++ b/censusreporter/apps/census/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
-from django.urls import re_path
+from django.urls import path, re_path, reverse_lazy
 from django.contrib import admin
-from django.urls import reverse_lazy
 from django.http import HttpResponse
 from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView, RedirectView
@@ -28,72 +27,72 @@ COMPARISON_FORMATS = 'map|table|distribution'
 BLOCK_ROBOTS = getattr(settings, 'BLOCK_ROBOTS', False)
 
 urlpatterns = [
-    re_path(
-        route='^$',
+    path(
+        route='',
         view=cache_page(STANDARD_CACHE_TIME)(HomepageView.as_view()),
         kwargs={},
         name='homepage',
     ),
 
     re_path(
-        route='^profiles/(?P<fragment>[a-zA-Z0-9\-]+)/$',
+        route=r'^profiles/(?P<fragment>[a-zA-Z0-9\-]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(GeographyDetailView.as_view()),
         kwargs={},
         name='geography_detail',
     ),
 
-    re_path(
-        route='^profiles/$',
+    path(
+        route='profiles/',
         view=RedirectView.as_view(url=reverse_lazy('search')),
         kwargs={},
         name='geography_search_redirect',
     ),
 
-    re_path(
-        route='^make-json/charts/$',
+    path(
+        route='make-json/charts/',
         view=csrf_exempt(MakeJSONView.as_view()),
         kwargs={},
         name='make_json_charts',
     ),
 
     # e.g. /table/B01001/
-    re_path(
-        route='^tables/B23002/$',
+    path(
+        route='tables/B23002/',
         view=RedirectView.as_view(url=reverse_lazy('table_detail', kwargs={'table': 'B23002A'})),
         kwargs={},
         name='redirect_B23002',
     ),
 
-    re_path(
-        route='^tables/C23002/$',
+    path(
+        route='tables/C23002/',
         view=RedirectView.as_view(url=reverse_lazy('table_detail', kwargs={'table': 'C23002A'})),
         kwargs={},
         name='redirect_C23002',
     ),
 
     re_path(
-        route='^tables/(?P<table>[a-zA-Z0-9]+)/$',
+        route=r'^tables/(?P<table>[a-zA-Z0-9]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(TableDetailView.as_view()),
         kwargs={},
         name='table_detail',
     ),
 
-    re_path(
-        route='^tables/$',
+    path(
+        route='tables/',
         view=RedirectView.as_view(url=reverse_lazy('search')),
         kwargs={},
         name='table_search',
     ),
 
-    re_path(
-        route='^search/$',
+    path(
+        route='search/',
         view=SearchResultsView.as_view(),
         kwargs={},
         name='search'
     ),
 
-    re_path(
-        route='^data/$',
+    path(
+        route='data/',
         view=RedirectView.as_view(url=reverse_lazy('table_search')),
         kwargs={},
         name='table_search_redirect',
@@ -101,108 +100,108 @@ urlpatterns = [
 
     # e.g. /table/B01001/
     re_path(
-        route='^data/(?P<format>%s)/$' % COMPARISON_FORMATS,
+        route=r'^data/(?P<format>%s)/$' % COMPARISON_FORMATS,
         view=cache_page(STANDARD_CACHE_TIME)(DataView.as_view()),
         kwargs={},
         name='data_detail',
     ),
 
-    re_path(
-        route='^topics/$',
+    path(
+        route='topics/',
         view=cache_page(STANDARD_CACHE_TIME)(TopicView.as_view()),
         kwargs={},
         name='topic_list',
     ),
 
-    re_path(
-        route='^topics/race-latino/?$',
+    path(
+        route='topics/race-latino/',
         view=RedirectView.as_view(url=reverse_lazy('topic_detail', kwargs={'topic_slug': 'race-hispanic'})),
         name='topic_latino_redirect',
     ),
 
-    re_path(
-        route='^topics/same-sex/?$',
+    path(
+        route='topics/same-sex/',
         view=RedirectView.as_view(url=reverse_lazy('topic_detail', kwargs={'topic_slug': 'sexual-orientation-gender-identity'})),
         name='topic_same_sex_redirect',
     ),
 
     re_path(
-        route='^topics/(?P<topic_slug>[-\w]+)/$',
+        route=r'^topics/(?P<topic_slug>[-\w]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(TopicView.as_view()),
         kwargs={},
         name='topic_detail',
     ),
 
     re_path(
-        route='^examples/(?P<example_slug>[-\w]+)/$',
+        route=r'^examples/(?P<example_slug>[-\w]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(ExampleView.as_view()),
         kwargs={},
         name='example_detail',
     ),
 
-    re_path(
-        route='^glossary/$',
+    path(
+        route='glossary/',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="glossary.html")),
         kwargs={},
         name='glossary',
     ),
 
-    re_path(
-        route='^about/$',
+    path(
+        route='about/',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="about.html")),
         kwargs={},
         name='about',
     ),
 
-    re_path(
-        route='^2020/$',
+    path(
+        route='2020/',
         view=cache_page(60 * 5)(Census2020View.as_view(template_name="2020.html")),
         kwargs={},
         name='2020',
     ),
 
-    re_path(
-        route='^acs-2020-update/$',
+    path(
+        route='acs-2020-update/',
         view=cache_page(60 * 5)(Census2020View.as_view(template_name="acs-2020-update.html")),
         kwargs={},
         name='acs-2020-update',
     ),
 
-    re_path(
-        route='^locate/$',
+    path(
+        route='locate/',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="locate/locate.html")),
         kwargs={},
         name='locate',
     ),
 
-    re_path(
-        route='^user_geo/$',
+    path(
+        route='user_geo/',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="user_geo/index.html")),
         kwargs={},
         name='user_geo',
     ),
     re_path(
-        route='^user_geo/(?P<hash_digest>[A-Fa-f0-9]{32})/$',
+        route=r'^user_geo/(?P<hash_digest>[A-Fa-f0-9]{32})/$',
         # don't cache as it mucks with acknowledging the async processing
         view=UserGeographyDetailView.as_view(template_name="user_geo/detail.html"),
         kwargs={},
         name='user_geo_detail',
     ),
 
-    re_path(
-        route='^healthcheck$',
+    path(
+        route='healthcheck',
         view=HealthcheckView.as_view(),
         kwargs={},
         name='healthcheck',
     ),
 
-    re_path(
-        route='^robots.txt$',
+    path(
+        route='robots.txt',
         view=robots
     ),
 
-    re_path(
-        route='^topics/sitemap.xml$',
+    path(
+        route='topics/sitemap.xml',
         view=SitemapTopicsView.as_view(),
         kwargs={},
         name='sitemap_topics'

--- a/censusreporter/apps/census/urls.py
+++ b/censusreporter/apps/census/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.urls import reverse_lazy
 from django.http import HttpResponse
@@ -28,181 +28,181 @@ COMPARISON_FORMATS = 'map|table|distribution'
 BLOCK_ROBOTS = getattr(settings, 'BLOCK_ROBOTS', False)
 
 urlpatterns = [
-    url(
-        regex='^$',
+    re_path(
+        route='^$',
         view=cache_page(STANDARD_CACHE_TIME)(HomepageView.as_view()),
         kwargs={},
         name='homepage',
     ),
 
-    url(
-        regex='^profiles/(?P<fragment>[a-zA-Z0-9\-]+)/$',
+    re_path(
+        route='^profiles/(?P<fragment>[a-zA-Z0-9\-]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(GeographyDetailView.as_view()),
         kwargs={},
         name='geography_detail',
     ),
 
-    url(
-        regex='^profiles/$',
+    re_path(
+        route='^profiles/$',
         view=RedirectView.as_view(url=reverse_lazy('search')),
         kwargs={},
         name='geography_search_redirect',
     ),
 
-    url(
-        regex='^make-json/charts/$',
+    re_path(
+        route='^make-json/charts/$',
         view=csrf_exempt(MakeJSONView.as_view()),
         kwargs={},
         name='make_json_charts',
     ),
 
     # e.g. /table/B01001/
-    url(
-        regex='^tables/B23002/$',
+    re_path(
+        route='^tables/B23002/$',
         view=RedirectView.as_view(url=reverse_lazy('table_detail', kwargs={'table': 'B23002A'})),
         kwargs={},
         name='redirect_B23002',
     ),
 
-    url(
-        regex='^tables/C23002/$',
+    re_path(
+        route='^tables/C23002/$',
         view=RedirectView.as_view(url=reverse_lazy('table_detail', kwargs={'table': 'C23002A'})),
         kwargs={},
         name='redirect_C23002',
     ),
 
-    url(
-        regex='^tables/(?P<table>[a-zA-Z0-9]+)/$',
+    re_path(
+        route='^tables/(?P<table>[a-zA-Z0-9]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(TableDetailView.as_view()),
         kwargs={},
         name='table_detail',
     ),
 
-    url(
-        regex='^tables/$',
+    re_path(
+        route='^tables/$',
         view=RedirectView.as_view(url=reverse_lazy('search')),
         kwargs={},
         name='table_search',
     ),
 
-    url(
-        regex='^search/$',
+    re_path(
+        route='^search/$',
         view=SearchResultsView.as_view(),
         kwargs={},
         name='search'
     ),
 
-    url(
-        regex='^data/$',
+    re_path(
+        route='^data/$',
         view=RedirectView.as_view(url=reverse_lazy('table_search')),
         kwargs={},
         name='table_search_redirect',
     ),
 
     # e.g. /table/B01001/
-    url(
-        regex='^data/(?P<format>%s)/$' % COMPARISON_FORMATS,
+    re_path(
+        route='^data/(?P<format>%s)/$' % COMPARISON_FORMATS,
         view=cache_page(STANDARD_CACHE_TIME)(DataView.as_view()),
         kwargs={},
         name='data_detail',
     ),
 
-    url(
-        regex='^topics/$',
+    re_path(
+        route='^topics/$',
         view=cache_page(STANDARD_CACHE_TIME)(TopicView.as_view()),
         kwargs={},
         name='topic_list',
     ),
 
-    url(
-        regex='^topics/race-latino/?$',
+    re_path(
+        route='^topics/race-latino/?$',
         view=RedirectView.as_view(url=reverse_lazy('topic_detail', kwargs={'topic_slug': 'race-hispanic'})),
         name='topic_latino_redirect',
     ),
 
-    url(
-        regex='^topics/same-sex/?$',
+    re_path(
+        route='^topics/same-sex/?$',
         view=RedirectView.as_view(url=reverse_lazy('topic_detail', kwargs={'topic_slug': 'sexual-orientation-gender-identity'})),
         name='topic_same_sex_redirect',
     ),
 
-    url(
-        regex='^topics/(?P<topic_slug>[-\w]+)/$',
+    re_path(
+        route='^topics/(?P<topic_slug>[-\w]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(TopicView.as_view()),
         kwargs={},
         name='topic_detail',
     ),
 
-    url(
-        regex='^examples/(?P<example_slug>[-\w]+)/$',
+    re_path(
+        route='^examples/(?P<example_slug>[-\w]+)/$',
         view=cache_page(STANDARD_CACHE_TIME)(ExampleView.as_view()),
         kwargs={},
         name='example_detail',
     ),
 
-    url(
-        regex='^glossary/$',
+    re_path(
+        route='^glossary/$',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="glossary.html")),
         kwargs={},
         name='glossary',
     ),
 
-    url(
-        regex='^about/$',
+    re_path(
+        route='^about/$',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="about.html")),
         kwargs={},
         name='about',
     ),
 
-    url(
-        regex='^2020/$',
+    re_path(
+        route='^2020/$',
         view=cache_page(60 * 5)(Census2020View.as_view(template_name="2020.html")),
         kwargs={},
         name='2020',
     ),
 
-    url(
-        regex='^acs-2020-update/$',
+    re_path(
+        route='^acs-2020-update/$',
         view=cache_page(60 * 5)(Census2020View.as_view(template_name="acs-2020-update.html")),
         kwargs={},
         name='acs-2020-update',
     ),
 
-    url(
-        regex='^locate/$',
+    re_path(
+        route='^locate/$',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="locate/locate.html")),
         kwargs={},
         name='locate',
     ),
 
-    url(
-        regex='^user_geo/$',
+    re_path(
+        route='^user_geo/$',
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="user_geo/index.html")),
         kwargs={},
         name='user_geo',
     ),
-    url(
-        regex='^user_geo/(?P<hash_digest>[A-Fa-f0-9]{32})/$',
+    re_path(
+        route='^user_geo/(?P<hash_digest>[A-Fa-f0-9]{32})/$',
         # don't cache as it mucks with acknowledging the async processing
         view=UserGeographyDetailView.as_view(template_name="user_geo/detail.html"),
         kwargs={},
         name='user_geo_detail',
     ),
 
-    url(
-        regex='^healthcheck$',
+    re_path(
+        route='^healthcheck$',
         view=HealthcheckView.as_view(),
         kwargs={},
         name='healthcheck',
     ),
 
-    url(
-        regex='^robots.txt$',
+    re_path(
+        route='^robots.txt$',
         view=robots
     ),
 
-    url(
-        regex='^topics/sitemap.xml$',
+    re_path(
+        route='^topics/sitemap.xml$',
         view=SitemapTopicsView.as_view(),
         kwargs={},
         name='sitemap_topics'

--- a/censusreporter/config/base/settings.py
+++ b/censusreporter/config/base/settings.py
@@ -23,7 +23,6 @@ TIME_ZONE = 'America/Chicago'
 LANGUAGE_CODE = 'en-us'
 SITE_ID = 1
 USE_I18N = False
-USE_L10N = True
 USE_TZ = True
 SECRET_KEY = '!%j-u4&(q8qu4@dq=ukth27+q!v-!h^jck14bf=spqht847$4q'
 
@@ -70,7 +69,14 @@ MIDDLEWARE = (
     'whitenoise.middleware.WhiteNoiseMiddleware',
 )
 
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'censusreporter.wsgi.application'

--- a/censusreporter/config/dev/urls.py
+++ b/censusreporter/config/dev/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url, include
+from django.urls import include, re_path
 from censusreporter.config.base.urls import urlpatterns, handler500
 
 if settings.DEBUG:
@@ -19,8 +19,8 @@ if settings.DEBUG:
         return static.serve(request, path, document_root=STATIC_SITEMAP_DIR, **kwargs)
 
     urlpatterns += [
-        url(
-            regex   = '^(?P<path>sitemap.*\.xml)$',
+        re_path(
+            route   = '^(?P<path>sitemap.*\.xml)$',
             view    = dev_sitemap_serve,
             name    = 'sitemaps',
         )

--- a/censusreporter/config/dev/urls.py
+++ b/censusreporter/config/dev/urls.py
@@ -20,7 +20,7 @@ if settings.DEBUG:
 
     urlpatterns += [
         re_path(
-            route   = '^(?P<path>sitemap.*\.xml)$',
+            route   = r'^(?P<path>sitemap.*\.xml)$',
             view    = dev_sitemap_serve,
             name    = 'sitemaps',
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-Django==3.2.24
+Django==4.2.16
 Fabric==1.13.1
-boto==2.49.0
+boto3==1.35.23
 django-redis-cache==3.0.0
-lxml==4.9.1
+lxml==4.9.4
 newrelic==9.6.0
 redis==3.5.3
 requests==2.31.0
 requests-cache==1.2.0
-six==1.13.0
+six==1.16.0
 whitenoise==5.2.0


### PR DESCRIPTION
Seeking to get the project running with Python 3.12, I made the necessary changes to migrate to Django 4.2 and bumped other problematic dependencies.

Changes:
- Upgrades to Django 4.2
   - Uses `re_path` and `path` for routes after removal of `url` method
- Migrates boto to boto3
   - Since I'm not using this locally, **this is untested!**
- Bumps six, lxml