### PR TITLE
Issue#313

### DIFF
--- a/censusreporter/apps/census/templates/profile/_blocks/_stat_list.html
+++ b/censusreporter/apps/census/templates/profile/_blocks/_stat_list.html
@@ -1,4 +1,4 @@
-{% load humanize comparatives %}
+{% load humanize comparatives cr_json_script %}
 {% if not stat_wrapper == 'false' %}<a class="stat {{ stat_type }}{% if wrapper_class %} {{ wrapper_class }}{% endif %}">{% endif %}
     <span class="{% if stat_class %}{{ stat_class }}{% else %}primary{% endif %}">
         <span class="value">
@@ -45,3 +45,11 @@
     </ul>
     {% endif %}
 {% if not stat_wrapper == 'false' %}</a>{% endif %}
+{% if stat.metadata %}
+    {% with stat_id=stat.metadata.table_id|slugify|add:'-'|add:stat.name|slugify %}
+        {{ stat|cr_json_script:stat_id }}
+        <div class="action-links">
+            <a class="stat-get-data" data-stat-id="{{ stat_id }}" data-stat-type="{{ stat_type }}">Show data</a>
+        </div>
+    {% endwith %}
+{% endif %}


### PR DESCRIPTION
### Summary

- Embedded metadata for profile “big number” stats, enabling a new Show data control for each stat block and wiring a link to the underlying ACS table

- Added client-side logic to build an inline data drawer with formatted values, MOEs, and a View table link for the source table(s) when the Show data control is toggled

### Testing

- ✅ node --check censusreporter/apps/census/static/js/app.js

- ⚠️ python manage.py test (missing module: corsheaders)

### Notes
Full test suite could not run because required dependencies (e.g., corsheaders) are not installed in the environment; installing all requirements failed due to lxml build issues.