### PR TITLE
Add ACS 2024 releases and fix comparatives crash

### DIFF
--- a/censusreporter/apps/census/static/js/app.js
+++ b/censusreporter/apps/census/static/js/app.js
@@ -104,6 +104,8 @@ var sumlevMap = {
 };
 
 var releaseNames = {
+    'acs2024_5yr': {'name': 'ACS 2024 5-year', 'years': '2020-2024'},
+    'acs2024_1yr': {'name': 'ACS 2024 1-year', 'years': '2024'},
     'acs2023_5yr': {'name': 'ACS 2023 5-year', 'years': '2019-2023'},
     'acs2023_1yr': {'name': 'ACS 2023 1-year', 'years': '2023'},
     'acs2022_5yr': {'name': 'ACS 2022 5-year', 'years': '2018-2022'},

--- a/censusreporter/apps/census/templatetags/comparatives.py
+++ b/censusreporter/apps/census/templatetags/comparatives.py
@@ -60,7 +60,12 @@ def comparison_index_phrase(value):
     thresholds = list(sorted(COMPARISON_PHRASE_MAP.keys()))
 
     # get highest boundary that's less than the index value we've been passed
-    phrase_key = max(filter(lambda t: t <= index, thresholds))
+    matching = list(filter(lambda t: t <= index, thresholds))
+    if not matching:
+        # index is below the lowest threshold, use the lowest
+        phrase_key = thresholds[0]
+    else:
+        phrase_key = max(matching)
 
     phrase_bits = COMPARISON_PHRASE_MAP[phrase_key]
     phrase = "<strong>%s</strong> %s" % (phrase_bits[0], phrase_bits[1])

--- a/censusreporter/apps/census/utils.py
+++ b/censusreporter/apps/census/utils.py
@@ -159,6 +159,8 @@ SUMLEV_CHOICES['Schools'] = [
 ]
 
 ACS_RELEASES = {
+    'acs2024_5yr': {'name': 'ACS 2024 5-Year', 'slug': 'acs2024_5yr', 'years': '2020-2024'},
+    'acs2024_1yr': {'name': 'ACS 2024 1-Year', 'slug': 'acs2024_1yr', 'years': '2024'},
     'acs2023_5yr': {'name': 'ACS 2023 5-Year', 'slug': 'acs2023_5yr', 'years': '2019-2023'},
     'acs2023_1yr': {'name': 'ACS 2023 1-Year', 'slug': 'acs2023_1yr', 'years': '2023'},
     'acs2022_5yr': {'name': 'ACS 2022 5-Year', 'slug': 'acs2022_5yr', 'years': '2018-2022'},


### PR DESCRIPTION
## Summary
- Add ACS 2024 1-year and 5-year entries to `ACS_RELEASES` in `utils.py` and `releaseNames` in `app.js`. Without these, `name_to_slug` couldn't convert release IDs like `ACS_2024_1-year` to proper API slugs, causing embed JSON generation to fail.
- Fix `ValueError: max() arg is an empty sequence` crash in `comparison_index_phrase` when the comparison index is negative (below the lowest threshold of 0).

## Test plan
- [ ] Verify embed generation works for ACS 2024 1-year profiles
- [ ] Verify profile pages render without comparatives errors for places with negative comparison indices