### PR TITLE
Add /aggregate/ tool: ACS data for a custom drawn/uploaded geometry (with MoE)

### DIFF
--- a/censusreporter/apps/census/static/js/acs_aggregate.js
+++ b/censusreporter/apps/census/static/js/acs_aggregate.js
@@ -15,6 +15,9 @@
   // release must be used to fetch the participating geographies' shapes.
   var GEOM_TIGER_RELEASE = "tiger2024";
   var GEOM_CHUNK_SIZE = 80; // keep geo/show GET URLs comfortably short
+  // Geographies overlapping the shape by less than this fraction of their own
+  // area still contribute their FULL value, so they tend to overstate totals.
+  var LOW_OVERLAP_THRESHOLD = 0.10;
 
   var map = L.map("map").setView([39.8283, -98.5795], 4);
   L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -185,8 +188,33 @@
     document.getElementById("suppressed-note").innerHTML = "";
     document.getElementById("component-summary").textContent = "";
     document.getElementById("download-csv").style.display = "none";
+    var warn = document.getElementById("overlap-warning");
+    warn.style.display = "none";
+    warn.innerHTML = "";
     removeComponentLayer();
     setStatus(statusMsg || "");
+  }
+
+  // Warn when whole-geography inclusion is likely overcounting: some included
+  // geographies barely overlap the shape yet contribute their full value.
+  function renderOverlapWarning(components) {
+    var el = document.getElementById("overlap-warning");
+    var low = (components || []).filter(function (c) {
+      return c.area_frac < LOW_OVERLAP_THRESHOLD;
+    });
+    if (low.length === 0) {
+      el.style.display = "none";
+      el.innerHTML = "";
+      return;
+    }
+    var pct = Math.round(LOW_OVERLAP_THRESHOLD * 100);
+    var faintest = Math.round(Math.min.apply(null, low.map(function (c) { return c.area_frac; })) * 100);
+    el.innerHTML = "⚠️ <strong>" + low.length + " of " + components.length +
+      " geographies</strong> overlap your shape by less than " + pct +
+      "% of their area (as little as " + faintest + "%), but their <em>full</em> values are still " +
+      "counted — so these totals are probably overstated. Raise the &ldquo;Min. overlap&rdquo; " +
+      "slider to drop them, or treat the totals as an upper bound.";
+    el.style.display = "block";
   }
 
   function removeComponentLayer() {
@@ -273,6 +301,7 @@
       (names.length ? ": " + names.join(", ") + more : "");
     setStatus("");
 
+    renderOverlapWarning(result.components);
     renderComponents(result.components);
 
     var container = document.getElementById("results");

--- a/censusreporter/apps/census/static/js/acs_aggregate.js
+++ b/censusreporter/apps/census/static/js/acs_aggregate.js
@@ -1,0 +1,285 @@
+/* Interactive ACS aggregation for an arbitrary geometry.
+ *
+ * Lets the user draw or upload a polygon, then calls the census-api endpoint
+ * POST /1.0/aggregate/acs/<release> to total ACS estimates (and combine their
+ * margins of error) across the overlapping geographies of a chosen level.
+ *
+ * Deliberately dependency-light (vanilla JS + Leaflet/Leaflet.draw globals) so
+ * it needs no Parcel build step.
+ */
+(function () {
+  "use strict";
+
+  var API_URL = window.CR_API_URL || "https://api.censusreporter.org";
+
+  var map = L.map("map").setView([39.8283, -98.5795], 4);
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    maxZoom: 19,
+    attribution: "&copy; OpenStreetMap contributors"
+  }).addTo(map);
+
+  var drawnItems = new L.FeatureGroup().addTo(map);
+  var drawControl = new L.Control.Draw({
+    edit: { featureGroup: drawnItems },
+    draw: {
+      polygon: { allowIntersection: false, showArea: true },
+      rectangle: {},
+      polyline: false, circle: false, marker: false, circlemarker: false
+    }
+  });
+  map.addControl(drawControl);
+
+  var lastResult = null;
+  var debounceTimer = null;
+
+  // --- geometry helpers -----------------------------------------------------
+
+  // Merge every polygon currently on the map into a single GeoJSON MultiPolygon
+  // that we can POST as one geometry. (A true union isn't done client-side;
+  // overlapping uploads are rare and the server's intersection test tolerates
+  // a MultiPolygon with touching parts.)
+  function currentGeometry() {
+    var polys = [];
+    drawnItems.eachLayer(function (layer) {
+      var gj = layer.toGeoJSON();
+      collectPolygons(gj, polys);
+    });
+    if (polys.length === 0) return null;
+    return { type: "MultiPolygon", coordinates: polys };
+  }
+
+  function collectPolygons(geojson, out) {
+    if (!geojson) return;
+    if (geojson.type === "FeatureCollection") {
+      geojson.features.forEach(function (f) { collectPolygons(f, out); });
+    } else if (geojson.type === "Feature") {
+      collectPolygons(geojson.geometry, out);
+    } else if (geojson.type === "Polygon") {
+      out.push(geojson.coordinates);
+    } else if (geojson.type === "MultiPolygon") {
+      geojson.coordinates.forEach(function (p) { out.push(p); });
+    }
+  }
+
+  // --- map events -----------------------------------------------------------
+
+  map.on(L.Draw.Event.CREATED, function (e) {
+    drawnItems.addLayer(e.layer);
+    scheduleRecompute();
+  });
+  map.on(L.Draw.Event.EDITED, scheduleRecompute);
+  map.on(L.Draw.Event.DELETED, function () {
+    if (drawnItems.getLayers().length === 0) {
+      clearResults("Draw or upload a shape to begin.");
+    } else {
+      scheduleRecompute();
+    }
+  });
+
+  // --- controls -------------------------------------------------------------
+
+  var thresholdSlider = document.getElementById("threshold-slider");
+  var thresholdValue = document.getElementById("threshold-value");
+  thresholdSlider.addEventListener("input", function () {
+    var pct = parseInt(thresholdSlider.value, 10);
+    thresholdValue.textContent = pct === 0 ? "any" : pct + "% of area";
+    scheduleRecompute();
+  });
+  document.getElementById("sumlevel-select").addEventListener("change", scheduleRecompute);
+  document.getElementById("release-select").addEventListener("change", scheduleRecompute);
+  document.getElementById("table-input").addEventListener("change", scheduleRecompute);
+
+  document.getElementById("geojson-upload").addEventListener("change", function (evt) {
+    var file = evt.target.files && evt.target.files[0];
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function () {
+      var parsed;
+      try {
+        parsed = JSON.parse(reader.result);
+      } catch (err) {
+        setStatus("Could not parse that file as GeoJSON.");
+        return;
+      }
+      var layer = L.geoJSON(parsed);
+      layer.eachLayer(function (l) { drawnItems.addLayer(l); });
+      try { map.fitBounds(drawnItems.getBounds()); } catch (e) { /* empty */ }
+      scheduleRecompute();
+    };
+    reader.readAsText(file);
+  });
+
+  document.getElementById("download-csv").addEventListener("click", downloadCsv);
+
+  // --- compute --------------------------------------------------------------
+
+  function scheduleRecompute() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(recompute, 350);
+  }
+
+  function parseTableIds() {
+    return document.getElementById("table-input").value
+      .split(",")
+      .map(function (t) { return t.trim().toUpperCase(); })
+      .filter(function (t) { return t.length > 0; });
+  }
+
+  function recompute() {
+    var geometry = currentGeometry();
+    if (!geometry) return;
+    var tableIds = parseTableIds();
+    if (tableIds.length === 0) {
+      setStatus("Enter at least one table ID (e.g. B01001).");
+      return;
+    }
+
+    var release = document.getElementById("release-select").value;
+    var sumlevel = document.getElementById("sumlevel-select").value;
+    var threshold = parseInt(thresholdSlider.value, 10) / 100;
+
+    setStatus("Calculating…");
+    fetch(API_URL + "/1.0/aggregate/acs/" + release, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        geometry: geometry,
+        table_ids: tableIds,
+        sumlevel: sumlevel,
+        threshold: threshold
+      })
+    })
+      .then(function (resp) {
+        return resp.json().then(function (body) {
+          return { ok: resp.ok, body: body };
+        });
+      })
+      .then(function (r) {
+        if (!r.ok) {
+          setStatus(r.body && r.body.error ? r.body.error : "Request failed.");
+          return;
+        }
+        lastResult = r.body;
+        render(r.body);
+      })
+      .catch(function () {
+        setStatus("Network error contacting the API.");
+      });
+  }
+
+  // --- rendering ------------------------------------------------------------
+
+  function setStatus(msg) {
+    document.getElementById("agg-status").textContent = msg;
+  }
+
+  function clearResults(statusMsg) {
+    lastResult = null;
+    document.getElementById("results").innerHTML = "";
+    document.getElementById("suppressed-note").innerHTML = "";
+    document.getElementById("component-summary").textContent = "";
+    document.getElementById("download-csv").style.display = "none";
+    setStatus(statusMsg || "");
+  }
+
+  function fmt(n) {
+    if (n === null || n === undefined || n === "") return "—";
+    return Math.round(n).toLocaleString();
+  }
+
+  function cvClass(estimate, moe) {
+    if (!estimate || estimate === 0) return "";
+    var cv = (moe / 1.645) / estimate; // coefficient of variation
+    if (cv <= 0.15) return "cv-low";
+    if (cv <= 0.30) return "cv-med";
+    return "cv-high";
+  }
+
+  function render(result) {
+    var n = result.components ? result.components.length : 0;
+    var levelLabel = document.querySelector("#sumlevel-select option:checked").textContent.toLowerCase();
+    var names = (result.components || []).slice(0, 5).map(function (c) { return c.name; });
+    var more = n > 5 ? " and " + (n - 5) + " more" : "";
+    document.getElementById("component-summary").textContent =
+      n + " " + levelLabel + " combined (" + result.release_name + ")" +
+      (names.length ? ": " + names.join(", ") + more : "");
+    setStatus("");
+
+    var container = document.getElementById("results");
+    container.innerHTML = "";
+    var suppressedAll = [];
+
+    Object.keys(result.tables).forEach(function (tableId) {
+      var t = result.tables[tableId];
+      var block = document.createElement("div");
+      block.className = "table-block";
+
+      var h = document.createElement("h3");
+      h.textContent = tableId + ". " + (t.title || "");
+      block.appendChild(h);
+
+      var table = document.createElement("table");
+      table.className = "agg-table";
+      table.innerHTML = "<thead><tr><th>Column</th><th>Estimate</th><th>MoE</th></tr></thead>";
+      var tbody = document.createElement("tbody");
+
+      Object.keys(t.estimate).forEach(function (colId) {
+        var est = t.estimate[colId];
+        var moe = t.error[colId];
+        var meta = (result.column_meta && result.column_meta[colId]) || {};
+        var tr = document.createElement("tr");
+        var label = meta.name || colId;
+        var indentClass = meta.indent ? " indent-" + Math.min(meta.indent, 3) : "";
+        tr.innerHTML =
+          '<td class="' + indentClass.trim() + '">' + escapeHtml(label) + '</td>' +
+          '<td class="num ' + cvClass(est, moe) + '">' + fmt(est) + '</td>' +
+          '<td class="num moe">&plusmn;' + fmt(moe) + '</td>';
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      block.appendChild(table);
+      container.appendChild(block);
+
+      (t.suppressed || []).forEach(function (s) {
+        suppressedAll.push(tableId + " " + s.column_id + ": " + s.reason);
+      });
+    });
+
+    var note = document.getElementById("suppressed-note");
+    if (suppressedAll.length) {
+      note.innerHTML = "<strong>Not aggregated (not additive across geographies):</strong><br>" +
+        suppressedAll.map(escapeHtml).join("<br>");
+    } else {
+      note.innerHTML = "";
+    }
+
+    document.getElementById("download-csv").style.display = n > 0 ? "inline-block" : "none";
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function downloadCsv() {
+    if (!lastResult) return;
+    var rows = [["table_id", "column_id", "estimate", "margin_of_error"]];
+    Object.keys(lastResult.tables).forEach(function (tableId) {
+      var t = lastResult.tables[tableId];
+      Object.keys(t.estimate).forEach(function (colId) {
+        rows.push([tableId, colId, t.estimate[colId], t.error[colId]]);
+      });
+    });
+    var csv = rows.map(function (r) {
+      return r.map(function (v) { return '"' + String(v) + '"'; }).join(",");
+    }).join("\n");
+    var blob = new Blob([csv], { type: "text/csv" });
+    var a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "acs_aggregate.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
+})();

--- a/censusreporter/apps/census/static/js/acs_aggregate.js
+++ b/censusreporter/apps/census/static/js/acs_aggregate.js
@@ -11,6 +11,10 @@
   "use strict";
 
   var API_URL = window.CR_API_URL || "https://api.censusreporter.org";
+  // TIGER release used by the aggregate endpoint's spatial selection; the same
+  // release must be used to fetch the participating geographies' shapes.
+  var GEOM_TIGER_RELEASE = "tiger2024";
+  var GEOM_CHUNK_SIZE = 80; // keep geo/show GET URLs comfortably short
 
   var map = L.map("map").setView([39.8283, -98.5795], 4);
   L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -31,6 +35,8 @@
 
   var lastResult = null;
   var debounceTimer = null;
+  var componentLayer = null; // Leaflet layer shading the participating geographies
+  var componentRequestSeq = 0; // guards against out-of-order async geom responses
 
   // --- geometry helpers -----------------------------------------------------
 
@@ -179,7 +185,69 @@
     document.getElementById("suppressed-note").innerHTML = "";
     document.getElementById("component-summary").textContent = "";
     document.getElementById("download-csv").style.display = "none";
+    removeComponentLayer();
     setStatus(statusMsg || "");
+  }
+
+  function removeComponentLayer() {
+    if (componentLayer) {
+      map.removeLayer(componentLayer);
+      componentLayer = null;
+    }
+  }
+
+  // Fetch the shapes of the geographies that participated in the aggregation and
+  // add them as a shaded layer beneath the user's drawn polygon.
+  function renderComponents(components) {
+    removeComponentLayer();
+    var geoids = (components || []).map(function (c) { return c.geoid; });
+    if (geoids.length === 0) return;
+
+    // Join area fraction back onto each shape for styling/tooltips.
+    var fracByGeoid = {};
+    components.forEach(function (c) { fracByGeoid[c.geoid] = c.area_frac; });
+
+    var seq = ++componentRequestSeq;
+    var chunks = [];
+    for (var i = 0; i < geoids.length; i += GEOM_CHUNK_SIZE) {
+      chunks.push(geoids.slice(i, i + GEOM_CHUNK_SIZE));
+    }
+
+    Promise.all(chunks.map(function (chunk) {
+      var url = API_URL + "/1.0/geo/show/" + GEOM_TIGER_RELEASE +
+        "?geo_ids=" + encodeURIComponent(chunk.join(","));
+      return fetch(url).then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; });
+    })).then(function (collections) {
+      // A newer request started while we were fetching — discard stale shapes.
+      if (seq !== componentRequestSeq) return;
+      var features = [];
+      collections.forEach(function (fc) {
+        if (fc && fc.features) features = features.concat(fc.features);
+      });
+      if (features.length === 0) return;
+
+      removeComponentLayer();
+      componentLayer = L.geoJSON({ type: "FeatureCollection", features: features }, {
+        style: function (feature) {
+          var frac = fracByGeoid[feature.properties.geoid] || 0;
+          return {
+            color: "#e8720c",
+            weight: 1,
+            fillColor: "#f6a04d",
+            // more overlap -> more opaque, so partial participants read as fainter
+            fillOpacity: 0.15 + 0.35 * Math.max(0, Math.min(1, frac))
+          };
+        },
+        onEachFeature: function (feature, layer) {
+          var frac = fracByGeoid[feature.properties.geoid];
+          var pct = frac !== undefined ? Math.round(frac * 100) + "% inside" : "";
+          layer.bindTooltip((feature.properties.name || feature.properties.geoid) +
+            (pct ? " (" + pct + ")" : ""));
+        }
+      }).addTo(map);
+      componentLayer.bringToBack();
+      drawnItems.bringToFront();
+    });
   }
 
   function fmt(n) {
@@ -204,6 +272,8 @@
       n + " " + levelLabel + " combined (" + result.release_name + ")" +
       (names.length ? ": " + names.join(", ") + more : "");
     setStatus("");
+
+    renderComponents(result.components);
 
     var container = document.getElementById("results");
     container.innerHTML = "";

--- a/censusreporter/apps/census/static/js/acs_aggregate.js
+++ b/censusreporter/apps/census/static/js/acs_aggregate.js
@@ -97,6 +97,7 @@
   document.getElementById("sumlevel-select").addEventListener("change", scheduleRecompute);
   document.getElementById("release-select").addEventListener("change", scheduleRecompute);
   document.getElementById("table-input").addEventListener("change", scheduleRecompute);
+  document.getElementById("weighting-toggle").addEventListener("change", scheduleRecompute);
 
   document.getElementById("geojson-upload").addEventListener("change", function (evt) {
     var file = evt.target.files && evt.target.files[0];
@@ -146,6 +147,7 @@
     var release = document.getElementById("release-select").value;
     var sumlevel = document.getElementById("sumlevel-select").value;
     var threshold = parseInt(thresholdSlider.value, 10) / 100;
+    var weighting = document.getElementById("weighting-toggle").checked ? "area" : "none";
 
     setStatus("Calculating…");
     fetch(API_URL + "/1.0/aggregate/acs/" + release, {
@@ -155,7 +157,8 @@
         geometry: geometry,
         table_ids: tableIds,
         sumlevel: sumlevel,
-        threshold: threshold
+        threshold: threshold,
+        weighting: weighting
       })
     })
       .then(function (resp) {
@@ -191,6 +194,9 @@
     var warn = document.getElementById("overlap-warning");
     warn.style.display = "none";
     warn.innerHTML = "";
+    var wnote = document.getElementById("weighting-note");
+    wnote.style.display = "none";
+    wnote.innerHTML = "";
     removeComponentLayer();
     setStatus(statusMsg || "");
   }
@@ -214,6 +220,21 @@
       "% of their area (as little as " + faintest + "%), but their <em>full</em> values are still " +
       "counted — so these totals are probably overstated. Raise the &ldquo;Min. overlap&rdquo; " +
       "slider to drop them, or treat the totals as an upper bound.";
+    el.style.display = "block";
+  }
+
+  function renderWeightingNote(weighted) {
+    var el = document.getElementById("weighting-note");
+    if (!weighted) {
+      el.style.display = "none";
+      el.innerHTML = "";
+      return;
+    }
+    el.innerHTML = "ℹ️ <strong>Overlap-weighted (approximate).</strong> Each geography's " +
+      "value is scaled by the share of its area inside your shape. This assumes people and " +
+      "characteristics are spread evenly across each geography, which is often not true — treat " +
+      "these as estimates. Margins of error are scaled too and will look smaller than the " +
+      "whole-geography totals.";
     el.style.display = "block";
   }
 
@@ -301,7 +322,11 @@
       (names.length ? ": " + names.join(", ") + more : "");
     setStatus("");
 
-    renderOverlapWarning(result.components);
+    var weighted = result.weighting === "area";
+    // Overcounting is a whole-geography problem; when apportioning by overlap the
+    // relevant caveat is the uniform-distribution assumption instead.
+    renderOverlapWarning(weighted ? [] : result.components);
+    renderWeightingNote(weighted);
     renderComponents(result.components);
 
     var container = document.getElementById("results");

--- a/censusreporter/apps/census/templates/aggregate/index.html
+++ b/censusreporter/apps/census/templates/aggregate/index.html
@@ -22,6 +22,17 @@
     .indent-1 { padding-left: 1.2em; } .indent-2 { padding-left: 2.4em; } .indent-3 { padding-left: 3.6em; }
     .cv-low { color: #2a7a2a; } .cv-med { color: #b8860b; } .cv-high { color: #b22222; }
     #suppressed-note { font-size: 0.85em; color: #b22222; margin-top: 10px; }
+    #overlap-warning {
+        display: none;
+        margin: 10px 0;
+        padding: 8px 12px;
+        font-size: 0.85em;
+        border: 1px solid #e0b000;
+        border-left: 4px solid #e0b000;
+        background: #fff8e1;
+        color: #6b5300;
+        border-radius: 3px;
+    }
     .table-block { margin-bottom: 24px; }
     .table-block h3 { margin-bottom: 2px; }
     .table-block .universe { font-size: 0.8em; color: #666; margin-top: 0; }
@@ -76,6 +87,7 @@
         <div id="agg-results-col">
             <p id="agg-status">Draw or upload a shape to begin.</p>
             <p id="component-summary" class="agg-hint"></p>
+            <div id="overlap-warning"></div>
             <button id="download-csv" style="display:none;">Download CSV</button>
             <div id="results"></div>
             <div id="suppressed-note"></div>

--- a/censusreporter/apps/census/templates/aggregate/index.html
+++ b/censusreporter/apps/census/templates/aggregate/index.html
@@ -1,0 +1,90 @@
+{% extends '_base.html' %}
+{% load static %}
+{% block head_title %}Aggregate ACS Data for a Custom Area — Census Reporter{% endblock %}
+
+{% block head_css_extra %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
+<style>
+    #agg-layout { display: flex; flex-wrap: wrap; gap: 20px; }
+    #agg-map-col { flex: 1 1 420px; min-width: 320px; }
+    #agg-results-col { flex: 1 1 420px; min-width: 320px; }
+    #map { width: 100%; height: 55vh; min-height: 360px; border: 1px solid #ccc; }
+    .agg-controls { margin: 12px 0; display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end; }
+    .agg-controls label { display: block; font-size: 0.85em; font-weight: bold; margin-bottom: 3px; }
+    .agg-controls .field { display: flex; flex-direction: column; }
+    #threshold-value { font-weight: normal; }
+    #agg-status { font-style: italic; color: #555; min-height: 1.2em; }
+    table.agg-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    table.agg-table th, table.agg-table td { padding: 4px 6px; border-bottom: 1px solid #eee; text-align: left; }
+    table.agg-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    table.agg-table .moe { color: #777; white-space: nowrap; }
+    .indent-1 { padding-left: 1.2em; } .indent-2 { padding-left: 2.4em; } .indent-3 { padding-left: 3.6em; }
+    .cv-low { color: #2a7a2a; } .cv-med { color: #b8860b; } .cv-high { color: #b22222; }
+    #suppressed-note { font-size: 0.85em; color: #b22222; margin-top: 10px; }
+    .table-block { margin-bottom: 24px; }
+    .table-block h3 { margin-bottom: 2px; }
+    .table-block .universe { font-size: 0.8em; color: #666; margin-top: 0; }
+    .agg-hint { font-size: 0.85em; color: #666; }
+</style>
+{% endblock head_css_extra %}
+
+{% block content %}
+<div id="content">
+    <h1>Aggregate ACS Data for a Custom Area</h1>
+    <p class="agg-hint">Draw a shape on the map (or upload a GeoJSON file), pick a Census table, and
+    Census Reporter will total the American Community Survey estimates for every geography of the
+    chosen level that overlaps your shape &mdash; correctly combining the margins of error. Statistics
+    that can't be added across areas (medians, per-capita, etc.) are listed but not aggregated.</p>
+
+    <div id="agg-layout">
+        <div id="agg-map-col">
+            <div id="map"></div>
+            <div class="agg-controls">
+                <div class="field">
+                    <label for="release-select">ACS release</label>
+                    <select id="release-select">
+                        <option value="acs2024_5yr" selected>ACS 2024 5-year</option>
+                        <option value="acs2024_1yr">ACS 2024 1-year</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="sumlevel-select">Build from</label>
+                    <select id="sumlevel-select">
+                        <option value="140" selected>Census tracts</option>
+                        <option value="150">Block groups</option>
+                        <option value="160">Places</option>
+                        <option value="050">Counties</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="threshold-slider">Min. overlap: <span id="threshold-value">any</span></label>
+                    <input type="range" id="threshold-slider" min="0" max="100" value="0" step="5">
+                </div>
+                <div class="field">
+                    <label for="table-input">Table(s)</label>
+                    <input type="text" id="table-input" value="B01001" size="16" placeholder="e.g. B01001">
+                </div>
+                <div class="field">
+                    <label for="geojson-upload">Upload GeoJSON</label>
+                    <input type="file" id="geojson-upload" accept=".json,.geojson,application/geo+json,application/json">
+                </div>
+            </div>
+            <p class="agg-hint">Use the polygon/rectangle tools at the top-left of the map to draw, or edit an existing shape.</p>
+        </div>
+
+        <div id="agg-results-col">
+            <p id="agg-status">Draw or upload a shape to begin.</p>
+            <p id="component-summary" class="agg-hint"></p>
+            <button id="download-csv" style="display:none;">Download CSV</button>
+            <div id="results"></div>
+            <div id="suppressed-note"></div>
+        </div>
+    </div>
+</div>
+
+<script>window.CR_API_URL = "{{ api_url }}";</script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
+<script src="{% static 'js/acs_aggregate.js' %}"></script>
+{% endblock content %}

--- a/censusreporter/apps/census/templates/aggregate/index.html
+++ b/censusreporter/apps/census/templates/aggregate/index.html
@@ -33,6 +33,17 @@
         color: #6b5300;
         border-radius: 3px;
     }
+    #weighting-note {
+        display: none;
+        margin: 10px 0;
+        padding: 8px 12px;
+        font-size: 0.85em;
+        border: 1px solid #7aa7d0;
+        border-left: 4px solid #7aa7d0;
+        background: #eef4fb;
+        color: #2c4a63;
+        border-radius: 3px;
+    }
     .table-block { margin-bottom: 24px; }
     .table-block h3 { margin-bottom: 2px; }
     .table-block .universe { font-size: 0.8em; color: #666; margin-top: 0; }
@@ -80,6 +91,12 @@
                     <label for="geojson-upload">Upload GeoJSON</label>
                     <input type="file" id="geojson-upload" accept=".json,.geojson,application/geo+json,application/json">
                 </div>
+                <div class="field">
+                    <label for="weighting-toggle" title="Scale each geography's value by the fraction of its area inside your shape">Weighting</label>
+                    <label class="agg-hint" style="font-weight:normal;">
+                        <input type="checkbox" id="weighting-toggle"> Weight by overlap (approximate)
+                    </label>
+                </div>
             </div>
             <p class="agg-hint">Use the polygon/rectangle tools at the top-left of the map to draw, or edit an existing shape.</p>
         </div>
@@ -88,6 +105,7 @@
             <p id="agg-status">Draw or upload a shape to begin.</p>
             <p id="component-summary" class="agg-hint"></p>
             <div id="overlap-warning"></div>
+            <div id="weighting-note"></div>
             <button id="download-csv" style="display:none;">Download CSV</button>
             <div id="results"></div>
             <div id="suppressed-note"></div>

--- a/censusreporter/apps/census/urls.py
+++ b/censusreporter/apps/census/urls.py
@@ -19,6 +19,7 @@ from .views import (
     TableDetailView,
     TopicView,
     UserGeographyDetailView,
+    AcsAggregateBuilderView,
     Census2020View,
     robots
 )
@@ -158,6 +159,12 @@ urlpatterns = [
         view=cache_page(STANDARD_CACHE_TIME)(TemplateView.as_view(template_name="user_geo/index.html")),
         kwargs={},
         name='user_geo',
+    ),
+
+    re_path('^aggregate/$',
+        view=cache_page(STANDARD_CACHE_TIME)(AcsAggregateBuilderView.as_view()),
+        kwargs={},
+        name='acs_aggregate',
     ),
     re_path('^user_geo/(?P<hash_digest>[A-Fa-f0-9]{32})/$',
         # don't cache as it mucks with acknowledging the async processing

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -1042,6 +1042,19 @@ class UserGeographyDetailView(TemplateView):
             context['message'] = f'ERROR: code {r.status_code}'
         return context
 
+class AcsAggregateBuilderView(TemplateView):
+    """Interactive tool for computing ACS estimates (with margins of error) over
+    an arbitrary user-drawn or uploaded geometry. The page talks directly to the
+    API's POST /1.0/aggregate/acs endpoint; this view only supplies the API base
+    URL to the template."""
+    template_name = 'aggregate/index.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['api_url'] = settings.API_URL
+        return context
+
+
 class Census2020View(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Adds the long-requested ability to compute ACS values for an **arbitrary geometry** the user draws or uploads, with correct margin-of-error propagation. Frontend for the new census-api endpoint (censusreporter/census-api#94).

## What this adds
- **New page `/aggregate/`** (`AcsAggregateBuilderView` + `aggregate/index.html`): a Leaflet + Leaflet.draw map where you draw or upload a polygon, choose an ACS release, summary level (tracts / block groups / places / counties), a minimum-overlap threshold slider, and one or more table IDs.
- **`static/js/acs_aggregate.js`**: dependency-light (no Parcel build) — debounced calls to `POST /1.0/aggregate/acs/<release>`, renders each table's estimate ± MoE with reliability coloring (coefficient of variation), lists any non-additive columns (medians, per-capita, …) that were suppressed, and exports CSV.

## How it works
The geometry is POSTed to the API, which finds the overlapping geographies via PostGIS, sums their estimates, and combines MoE as √Σ MoE² (with the Census zero-estimate rule). Whole-geography inclusion is decided by real polygon intersection with a user-adjustable area threshold (default: any overlap).

## Not yet verified / follow-ups
- Needs a running Django + live API to click through end-to-end (Django isn't installed in the build env here; Python/JS both compile clean).
- v1 upload supports **GeoJSON**; shapefile upload is a follow-up (the existing `reproject` bundle can be wired in).
- The results panel lists included geographies by name but doesn't yet **shade them on the map** (the endpoint returns the component list without geometries to stay light) — a natural follow-up.
- No nav link added yet; the page is reachable at `/aggregate/`.