### PR TITLE
Build canonical profile URLs client-side to skip redirect round trips

### DIFF
--- a/censusreporter/apps/census/static/js/address.search.js
+++ b/censusreporter/apps/census/static/js/address.search.js
@@ -455,8 +455,8 @@ function initialize_map() {
 
     map.on('click', 'polys-layer-fill', (e) => {
         if (e && e.features && e.features.length > 0) {
-            window.location.href = '/profiles/' + e.features[0].properties.full_geoid;
-
+            var clickedFeature = e.features[0].properties;
+            window.location.href = '/profiles/' + clickedFeature.full_geoid + '-' + slugify(clickedFeature.full_name) + '/';
         }
     })
 

--- a/censusreporter/apps/census/static/js/comparisons.js
+++ b/censusreporter/apps/census/static/js/comparisons.js
@@ -625,8 +625,7 @@ function Comparison(options, callback) {
                     if (e && e.features && e.features.length > 0) {
                         const props = e.features[0].properties
                         comparison.trackEvent('Map View', 'Click to visit geo detail page', props.name);
-                        window.location.href = '/profiles/' + props.geoid;
-
+                        window.location.href = '/profiles/' + props.geoid + '-' + slugify(props.name) + '/';
                     }
                 })
 
@@ -947,7 +946,7 @@ function Comparison(options, callback) {
 
         chartPointLabels.append('a')
             .classed('label-title', true)
-            .attr('href', function(d) { return '/profiles/' + d.geoID + '/'; })
+            .attr('href', function(d) { return '/profiles/' + d.geoID + '-' + slugify(d.name) + '/'; })
             .text(function(d) { return d.name });
 
         var addPct = function() {

--- a/censusreporter/apps/census/static/js/cr-leaflet.js
+++ b/censusreporter/apps/census/static/js/cr-leaflet.js
@@ -44,7 +44,7 @@ CensusReporter = {
                 var censusreporter_url = options.censusreporter_url;
                 var autoclick_handler = function(data, layer) {
                     layer.on('click',function() {
-                        window.open(censusreporter_url + "/profiles/" + data.properties.geoid);
+                        window.open(censusreporter_url + "/profiles/" + data.properties.geoid + "-" + slugify(data.properties.name) + "/");
                     });
                 }
                 if (options.onEachFeature) {
@@ -363,7 +363,7 @@ CensusReporter.SummaryLevelLayer = CensusReporter.GeoJSONLayer.extend({
     _defaultGeojsonOptions: {
         onEachFeature: function(feature, layer) {
             // you can wire behavior to each "feature", or place outline.
-            var profileURL = 'https://censusreporter.org/profiles/' + feature.properties.geoid;
+            var profileURL = 'https://censusreporter.org/profiles/' + feature.properties.geoid + '-' + slugify(feature.properties.name) + '/';
             layer.bindPopup("<a href='" + profileURL + "'>" + feature.properties.name + "</a>");
             if (this.style && this.mouseoverStyle) {
                 layer.on('mouseover', function() {

--- a/censusreporter/apps/census/static/js/widget.geo.select.js
+++ b/censusreporter/apps/census/static/js/widget.geo.select.js
@@ -15,7 +15,7 @@ var geoSelectEngine = new Bloodhound({
             var results = response.results;
             _.map(results, function(item) {
                 item['sumlev_name'] = sumlevMap[item['sumlevel']]['name'];
-                item['url'] = '/profiles/' + item['full_geoid'] + '-' + slugify(item['full_name']);
+                item['url'] = '/profiles/' + item['full_geoid'] + '-' + slugify(item['full_name']) + '/';
             })
             return results;
         }

--- a/censusreporter/apps/census/templates/profile/profile_detail.html
+++ b/censusreporter/apps/census/templates/profile/profile_detail.html
@@ -420,8 +420,8 @@
                     map.on('click', 'sumlev-tiles-layer-fill', (e) => {
                         if (e.features[0].properties.full_geoid != thisGeoID) {
                             if (e && e.features && e.features.length > 0) {
-                                window.location.href = '/profiles/' + e.features[0].properties.full_geoid;
-
+                                var clickedFeature = e.features[0].properties;
+                                window.location.href = '/profiles/' + clickedFeature.full_geoid + '-' + slugify(clickedFeature.display_name) + '/';
                             }
                         }
                     })


### PR DESCRIPTION
## Summary
Several places (map click handlers, geo-select typeahead, comparison charts) navigate to a profile page using just the bare geoid: `/profiles/<geoid>`. That triggers two server-side redirects before the real page loads:
1. `/profiles/<geoid>` -> 301 -> `/profiles/<geoid>/` (Django's `APPEND_SLASH`)
2. `/profiles/<geoid>/` -> 302 -> `/profiles/<geoid>-<slug>/` (`GeographyDetailView`'s slug canonicalization)

Both redirect responses are empty-bodied, but each hop is a full round trip, which is pure added latency for what's normally the most common navigation on the site (exploring nearby geographies from a profile page).

Every one of these call sites already has the geography's display name available locally (`display_name` / `full_name` / `name`, depending on which API endpoint the data came from — all ultimately the same `census_name_lookup.display_name` column, just exposed under different JSON keys). A JS `slugify()` already exists in `app.js` and is already used for this exact purpose elsewhere in `profile_detail.html`. So each site now builds the full canonical URL (`geoid-slug/`) directly:
- `profile_detail.html` — map click handler (mapbox)
- `address.search.js` — address-search results map click
- `comparisons.js` — comparison map click, and distribution-chart hovercard links
- `widget.geo.select.js` — typeahead already built the slug, just added the missing trailing slash
- `cr-leaflet.js` — both the autoclick handler and the default popup link builder

If the client-side slug guess doesn't match the server's canonical one (extremely unlikely — same underlying data, same algorithm), `GeographyDetailView` still redirects to the correct URL, so this is a strict improvement with no failure mode worse than today's behavior.

## Test plan
- [x] `manage.py test census` (8/8 passed)
- [x] Django template parses cleanly (`profile_detail.html`)
- [x] `node --check` on all four modified JS files
- [ ] Click through a few profile-page map neighbors, address-search results, and comparison charts in a browser and confirm direct navigation (no redirect hops in Network tab)