### PR TITLE
Hotfix: pin requests-cache to 1.3.3 (production 500s)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "newrelic==9.6.0",
     "redis==3.5.3",
     "requests==2.34.2",
-    "requests-cache==1.2.0",
+    "requests-cache==1.3.3",
     "six==1.13.0",
     "whitenoise==6.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ requires-dist = [
     { name = "newrelic", specifier = "==9.6.0" },
     { name = "redis", specifier = "==3.5.3" },
     { name = "requests", specifier = "==2.34.2" },
-    { name = "requests-cache", specifier = "==1.2.0" },
+    { name = "requests-cache", specifier = "==1.3.3" },
     { name = "six", specifier = "==1.13.0" },
     { name = "whitenoise", specifier = "==6.12.0" },
 ]
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "requests-cache"
-version = "1.2.0"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -264,9 +264,9 @@ dependencies = [
     { name = "url-normalize" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/f6/2a1078b61b5b21718b61500b08e84ecd525d94a162db782c1065f9f571c7/requests_cache-1.2.0.tar.gz", hash = "sha256:db1c709ca343cc1cd5b6c8b1a5387298eceed02306a6040760db538c885e3838", size = 3018038, upload-time = "2024-02-17T23:28:05.852Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/ab/a340c7f529646f16e5656a8ba1424ed0de406203e4554868491786628730/requests_cache-1.3.3.tar.gz", hash = "sha256:79b72d5ac5143992d1836ad78f4d8e65666061dd44e220548caab3723089826b", size = 101179, upload-time = "2026-07-03T19:48:57.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/23/863f517b5d74e297e669c88093ecd92e13a06c488e90acbd5507819049ac/requests_cache-1.2.0-py3-none-any.whl", hash = "sha256:490324301bf0cb924ff4e6324bd2613453e7e1f847353928b08adb0fdfb7f722", size = 61409, upload-time = "2024-02-17T23:28:03.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/bf/c1775e49b350225bd851576ba75263bc728d8f05c0e31439a45f3429cc7b/requests_cache-1.3.3-py3-none-any.whl", hash = "sha256:c8df20ff874ebfc026959e3874e6c12bd6724934cdb10925915908453d4b17e4", size = 70788, upload-time = "2026-07-03T19:48:56.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Production is currently returning 500s on profile pages and other views that fetch geography data (~25% error rate in recent samples). Root cause: my earlier security-patch PR bumped `requests` from 2.32.4 to 2.34.2, but `requests-cache` stayed pinned at 1.2.0, which isn't compatible with that newer `requests`. Every attempt to cache a response fails during serialization.

Traceback from production:
```
File ".../requests_cache/serializers/cattrs.py", line 72, in _
    response_dict = self.converter.unstructure(value)
...
NameError: name 'RequestsCookieJar' is not defined
```

## Fix
Bump `requests-cache` to 1.3.3 (latest), which declares `requests>=2.22` with no upper bound — keeps the `requests` security patch rather than reverting it.

## Verification
- Reproduced the exact failure locally (same `requests_cache.CachedSession` + `RedisCache` backend pattern used in `views.py`, against a real `redis:5.0.7` container matching production) — confirmed it fails with 1.2.0 and succeeds with 1.3.3 (cache miss then cache hit on a second request)
- `manage.py test census` (8/8 passed)
- Full real `docker build` of the production Dockerfile succeeds
- Ran the built image against a real `redis:5.0.7` container and a live profile page request (`/profiles/16000US1781087-wheeling-il/`) — the exact code path that was failing in production — returns `200`

## Urgency
This should be merged and deployed immediately given the current error rate.