### PR TITLE
Add INTERNAL_API_URL: let server-side census-api calls skip the public-internet hairpin

### DIFF
--- a/censusreporter/apps/census/profile.py
+++ b/censusreporter/apps/census/profile.py
@@ -6,7 +6,7 @@ import requests_cache
 
 from collections import OrderedDict
 from django.conf import settings
-from .utils import get_ratio, get_division, SUMMARY_LEVEL_DICT, ACS_RELEASES
+from .utils import api_cache_key, get_ratio, get_division, SUMMARY_LEVEL_DICT, ACS_RELEASES
 
 import logging
 logging.basicConfig()
@@ -16,6 +16,7 @@ r_session = requests_cache.CachedSession(
     cache_name='cr_api_cache',
     backend=requests_cache.RedisCache(connection=redis.StrictRedis.from_url(getattr(settings, 'REDIS_URL'))),
     expire_after=requests_cache.NEVER_EXPIRE,
+    key_fn=api_cache_key,
 )
 r_session.headers.update({'User-Agent': 'censusreporter.org frontend profile builder'})
 
@@ -251,7 +252,7 @@ def _filter_comparison_item_levels(item_levels):
     return levels
 
 def geo_profile(geoid, acs='latest'):
-    api = ApiClient(settings.API_URL)
+    api = ApiClient(settings.INTERNAL_API_URL)
 
     # both item_levels and comparison_geoids are used later
     item_levels = _filter_comparison_item_levels(api.get_parent_geoids(geoid)['parents'])

--- a/censusreporter/apps/census/templatetags/list_tables.py
+++ b/censusreporter/apps/census/templatetags/list_tables.py
@@ -15,7 +15,7 @@ register = template.Library()
 
 @register.inclusion_tag('topics/_blocks/_table_list.html')
 def list_tables(topics=None, prefix=None, exclude_prefix=None, codes=None, query=None):
-    api = ApiClient(settings.API_URL)
+    api = ApiClient(settings.INTERNAL_API_URL)
 
     if exclude_prefix:
         exclude_prefix = ['00', '98', '99'] + list(map(lambda x: x.strip(), exclude_prefix.split(',')))

--- a/censusreporter/apps/census/utils.py
+++ b/censusreporter/apps/census/utils.py
@@ -1,7 +1,26 @@
 from collections import OrderedDict
+import copy
 import re
+from urllib.parse import urlsplit, urlunsplit
 
 from django.urls import reverse
+from requests_cache.backends.base import create_key as _default_cache_key
+
+
+def api_cache_key(request, **kwargs):
+    """Cache key for r_session requests, based on the public API URL
+    regardless of which host the request actually went to.
+
+    settings.INTERNAL_API_URL lets the app call census-api directly over the
+    internal network instead of round-tripping through the public internet,
+    without invalidating the existing (NEVER_EXPIRE) Redis cache: a request to
+    the internal host hashes identically to the same request against the
+    public API, so it transparently hits whatever's already cached there.
+    """
+    normalized = copy.copy(request)
+    parts = urlsplit(request.url)
+    normalized.url = urlunsplit(('https', 'api.censusreporter.org', parts.path, parts.query, ''))
+    return _default_cache_key(normalized, **kwargs)
 
 
 def get_object_or_none(klass, *args, **kwargs):

--- a/censusreporter/apps/census/views.py
+++ b/censusreporter/apps/census/views.py
@@ -21,6 +21,7 @@ from django.utils.text import slugify
 from django.views.generic import View, TemplateView
 
 from .utils import (
+    api_cache_key,
     parse_table_id,
     TOPIC_FILTERS,
     SUMLEV_CHOICES,
@@ -41,6 +42,7 @@ r_session = requests_cache.CachedSession(
     backend=requests_cache.RedisCache(connection=redis.StrictRedis.from_url(getattr(settings, 'REDIS_URL'))),
     cache_name='censusreporter_cache',
     expire_after=requests_cache.NEVER_EXPIRE,
+    key_fn=api_cache_key,
 )
 r_session.headers.update({'User-Agent': 'censusreporter.org frontend'})
 
@@ -122,7 +124,7 @@ class TableDetailView(TemplateView):
                 table_argument = table_argument.replace('PR', 'APR')
             else:
                 table_argument = table_argument + 'A'
-            endpoint = f"{settings.API_URL}/2.0/table/latest/{table_argument}"
+            endpoint = f"{settings.INTERNAL_API_URL}/2.0/table/latest/{table_argument}"
 
             if r_session.get(endpoint).status_code == 200:
                 return HttpResponseRedirect(
@@ -131,7 +133,7 @@ class TableDetailView(TemplateView):
             raise e
 
     def get_tabulation_data(self, table_code):
-        endpoint = f"{settings.API_URL}/1.0/tabulation/{table_code}"
+        endpoint = f"{settings.INTERNAL_API_URL}/1.0/tabulation/{table_code}"
         r = r_session.get(endpoint)
         status_code = r.status_code
 
@@ -227,7 +229,7 @@ class TableDetailView(TemplateView):
         return related_topic_pages
 
     def get_table_data(self, table_code):
-        endpoint = f"{settings.API_URL}/2.0/table/latest/{table_code}"
+        endpoint = f"{settings.INTERNAL_API_URL}/2.0/table/latest/{table_code}"
         r = r_session.get(endpoint)
 
         if r.status_code == 200:
@@ -602,7 +604,7 @@ class GeographyDetailView(TemplateView):
         pass
 
     def get_geography(self, geo_id):
-        endpoint = f"{settings.API_URL}/1.0/geo/tiger2024/{self.geo_id}"
+        endpoint = f"{settings.INTERNAL_API_URL}/1.0/geo/tiger2024/{self.geo_id}"
         r = r_session.get(endpoint)
         status_code = r.status_code
 
@@ -871,7 +873,7 @@ class SearchResultsView(TemplateView):
         search_data_all = {}
 
         cr_data = []
-        search_url = f"{settings.API_URL}/2.1/full-text/search"
+        search_url = f"{settings.INTERNAL_API_URL}/2.1/full-text/search"
         cr_resp = r_session.get(search_url, params={"q": query, "limit": 1000})
 
         if cr_resp.status_code == 200:
@@ -1015,7 +1017,7 @@ class UserGeographyDetailView(TemplateView):
         context = super().get_context_data(**kwargs)
         hash_digest = kwargs['hash_digest']
 
-        endpoint = f'{settings.API_URL}/1.0/user_geo/{hash_digest}'
+        endpoint = f'{settings.INTERNAL_API_URL}/1.0/user_geo/{hash_digest}'
         r = r_session.get(endpoint)
 
         if r.status_code == 404:
@@ -1058,7 +1060,7 @@ class AcsAggregateBuilderView(TemplateView):
 class Census2020View(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        endpoint = f'{settings.API_URL}/1.0/user_geo/list'
+        endpoint = f'{settings.INTERNAL_API_URL}/1.0/user_geo/list'
         try:
             r = r_session.get(endpoint)
 

--- a/censusreporter/config/base/settings.py
+++ b/censusreporter/config/base/settings.py
@@ -132,6 +132,13 @@ MANAGERS = ADMINS
 
 API_URL = os.environ.get('CENSUSREPORTER_API_URL', 'https://api.censusreporter.org')
 
+# Used for server-side calls to census-api only (browser-facing URLs always use
+# API_URL, since a browser can't reach an internal address). Defaults to
+# API_URL, so this is a no-op unless CENSUSREPORTER_INTERNAL_API_URL is set -
+# e.g. to reach census-api directly over the internal Docker network instead
+# of round-tripping through the public internet for every request.
+INTERNAL_API_URL = os.environ.get('CENSUSREPORTER_INTERNAL_API_URL', API_URL)
+
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 


### PR DESCRIPTION
## Summary
Tonight's incident: Django's own server-side calls to census-api go out through the public internet (`https://api.censusreporter.org`, through Cloudflare) instead of over the internal Docker network, even though both apps run on the same host. Under load, a gunicorn worker sits blocked holding that connection for however long the public round-trip takes; census-api being slow (its own load) makes that round-trip slow, which trips gunicorn's worker timeout, kills the worker, and the retry work piles onto an already-overloaded system. Confirmed via `docker exec`: **2.7ms internal vs 97.7ms public** for the same request (~35x).

## What this does
- New `settings.INTERNAL_API_URL`, defaulting to `settings.API_URL` (i.e. **a no-op unless explicitly configured**). Set via `CENSUSREPORTER_INTERNAL_API_URL`.
- Switched the 7 genuine server-side `r_session.get(...)` call sites in `views.py`, plus `profile.py`'s `geo_profile()` and `list_tables.py`'s table-list fetch, to build their request URL from `INTERNAL_API_URL` instead of `API_URL`.
- Left every browser-facing URL (`CR_API_URL` in `_base.html`, download links, the aggregate builder's `api_url` context var) on `API_URL` — a browser can't reach an internal Docker address, so those must stay public. Verified each of the ~11 `API_URL` usages in `views.py` individually to get this split right (one of them is a Mapbox geocoding call that doesn't use `API_URL` at all, for instance).

## The cache-continuity problem, and how it's handled
`r_session` (both instances - `profile.py` and `views.py` have separate `requests_cache.CachedSession`s) caches responses in Redis with `expire_after=NEVER_EXPIRE`. By default, `requests_cache` keys its cache on the full request URL, including host. Naively switching the request host would silently orphan the *entire* existing cache (observed at multiple GB in production) — an accidental full cache-bust is exactly the failure mode that caused tonight's incident in the first place.

Fix: a custom `key_fn` (`api_cache_key` in `utils.py`) that always hashes as if the request were made to the public API host, regardless of which host it actually went to. Verified locally (see below) that this produces byte-identical keys to the current unmodified default for existing public-URL requests (so nothing already cached is invalidated), and that internal- and public-URL requests for the same resource collide to the same key (so a request routed internally transparently finds what's already cached).

## Rollout plan
This PR is safe to merge and deploy as-is — `INTERNAL_API_URL` defaults to `API_URL`, so it changes nothing until explicitly configured. The actual cutover is a separate, trivially-reversible step: `dokku config:set censusreporter CENSUSREPORTER_INTERNAL_API_URL=http://census-api.web:5000` (both apps are already on a shared Docker network with a stable DNS alias for this). Reverting is `dokku config:unset`, no redeploy needed either way.

## Test plan
- [x] `manage.py test census` (10/10 passing)
- [x] Real `docker build` of the production Dockerfile succeeds
- [x] Verified locally (outside the app) that `api_cache_key` produces the same hash as the current default `create_key` for existing public-URL requests, and that public/internal URLs for the same resource collide
- [x] Confirmed real internal network connectivity + latency via `docker exec` on the actual host: 2.7-5ms internal vs 97.7ms public
- [ ] After deploy: set `CENSUSREPORTER_INTERNAL_API_URL` and watch error rates / worker restart frequency under load