### PR TITLE
Disable nginx gzip so HTML responses keep Content-Length

### DIFF
--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -22,7 +22,7 @@ server {
   location    / {
     limit_req zone=one burst=30;
 
-    gzip on;
+    gzip off;
     gzip_min_length  1100;
     gzip_buffers  4 32k;
     gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
@@ -88,7 +88,7 @@ server {
   location    / {
     limit_req zone=one burst=30;
 
-    gzip on;
+    gzip off;
     gzip_min_length  1100;
     gzip_buffers  4 32k;
     gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;


### PR DESCRIPTION
## Summary
- nginx's gzip module always compresses `text/html` regardless of the `gzip_types` list, and Cloudflare's origin-pull requests always send `Accept-Encoding: gzip`, so every cache_page-wrapped HTML view (homepage, profile pages, topics, tables, glossary, etc.) was losing its `Content-Length` header and switching to chunked transfer-encoding on the way out of nginx.
- Missing `Content-Length` disqualifies those responses from Cloudflare's Cache Reserve (which requires it), and generally makes response size/caching behavior less predictable.
- Cloudflare already compresses responses at the edge for end clients regardless of origin compression, so turning off nginx's own gzip doesn't change what browsers receive — it just stops nginx from re-compressing (and thereby stripping Content-Length) on the origin→Cloudflare hop.

## Test plan
- [ ] Deploy to a review/staging app and confirm `curl -I` on `/`, a `/profiles/<geoid>/` page, and `/topics/` shows a `Content-Length` header
- [ ] Confirm response bodies are still correctly served (no truncation) and pages render normally in a browser
- [ ] After deploying to production, verify via Cloudflare that Cache Reserve starts writing HTML entries (previously 0)